### PR TITLE
Day 1: Update WS state management, only show WS page when request is upgraded to WS

### DIFF
--- a/packages/devtools-network-console/src/actions/websocket/index.ts
+++ b/packages/devtools-network-console/src/actions/websocket/index.ts
@@ -25,6 +25,12 @@ export interface IWebsocketMessageLoggedAction {
     content: string;
 }
 
+export interface IWebsocketDisconnectedAction {
+    type: 'REQUEST_WEBSOCKET_DISCONNECTED';
+
+    requestId: string;
+}
+
 export function makeSendWebsocketMessageAction(requestId: string, messageBody: string): ISendWebsocketMessageAction {
     return {
         type: 'REQUEST_WEBSOCKET_SEND_MESSAGE',
@@ -43,9 +49,22 @@ export function makeWebsocketMessageLoggedAction(requestId: string, direction: W
     };
 }
 
+export function makeWebSocketDisconnectedAction(requestId: string): IWebsocketDisconnectedAction {
+    return {
+        type: 'REQUEST_WEBSOCKET_DISCONNECTED',
+        requestId
+    }
+}
+
 export function sendWsMessage(requestId: string, messageBody: string): ThunkAction<void, IView, void, AnyAction> {
     return async dispatch => {
         dispatch(makeSendWebsocketMessageAction(requestId, messageBody));
         WebSocketMock.instance(requestId).send(messageBody);
+    };
+}
+
+export function sendWsDisconnect(requestId: string): ThunkAction<void, IView, void, AnyAction> {
+    return async dispatch => {
+        dispatch(makeWebSocketDisconnectedAction(requestId));
     };
 }

--- a/packages/devtools-network-console/src/actions/websocket/index.ts
+++ b/packages/devtools-network-console/src/actions/websocket/index.ts
@@ -24,7 +24,7 @@ export interface IWebsocketMessageLoggedAction {
     time: ms;
     content: string;
 }
-
+// TODO: add support for client vs server disconnect
 export interface IWebsocketDisconnectedAction {
     type: 'REQUEST_WEBSOCKET_DISCONNECTED';
 

--- a/packages/devtools-network-console/src/host/web-application-host.ts
+++ b/packages/devtools-network-console/src/host/web-application-host.ts
@@ -47,7 +47,7 @@ export default class WebApplicationHost implements INetConsoleHost {
             WebSocketMock.instance('wss');
             const time = Math.random() * 1000;
             setTimeout(() => {
-                globalDispatch(makeWebsocketMessageLoggedAction('wss', 'recv', Math.floor(time), 'GREETINGS PROFESSOR FALKEN.'));
+                globalDispatch(makeWebsocketMessageLoggedAction('DEFAULT_REQUEST', 'recv', Math.floor(time), 'GREETINGS PROFESSOR FALKEN.'));
             }, time);
             return {
                 duration: 4,
@@ -192,7 +192,7 @@ const DEMO_JSON_RESPONSES = {
 export class WebSocketMock {
     private static _instance: WebSocketMock | null;
     public static instance(requestId: string) {
-        if (!WebSocketMock._instance) {
+        if (!WebSocketMock._instance || requestId !== WebSocketMock._instance.requestId) {
             WebSocketMock._instance = new WebSocketMock(requestId);
         }
         return WebSocketMock._instance;

--- a/packages/devtools-network-console/src/model/NetConsoleRequest.ts
+++ b/packages/devtools-network-console/src/model/NetConsoleRequest.ts
@@ -49,4 +49,5 @@ export interface INetConsoleResponseInternal {
     started: ms;
     status: ResponseStatus;
     response: IHttpResponse | null;
+    isWebsocketUpgrade?: boolean;
 }

--- a/packages/devtools-network-console/src/reducers/response/index.ts
+++ b/packages/devtools-network-console/src/reducers/response/index.ts
@@ -45,11 +45,21 @@ export default function reduceResponse(collection: ResponsesState = DEFAULT_RESP
             break;
 
         case 'RESPONSE_END_REQUEST':
+            let isWebsocketUpgrade = false;
+            if (action.response?.statusCode === 101 && action.response?.headers) {
+                for (const header of action.response?.headers) {
+                    if (header.key === "Upgrade" && header.value === "WebSocket"){
+                        isWebsocketUpgrade = true;
+                        break;
+                    }
+                }
+            }
             result = {
                 duration: Date.now() - state.started,
                 started: 0,
                 response: action.response,
                 status: action.status,
+                isWebsocketUpgrade
             };
             break;
 

--- a/packages/devtools-network-console/src/reducers/websocket/index.ts
+++ b/packages/devtools-network-console/src/reducers/websocket/index.ts
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { OrderedSet } from 'immutable';
-import { IWebsocketMessageLoggedAction, WSMsgDirection } from 'actions/websocket';
+import { OrderedSet, Map } from 'immutable';
+import { IWebsocketMessageLoggedAction, WSMsgDirection, IWebsocketDisconnectedAction } from 'actions/websocket';
 import { ms } from 'network-console-shared';
+import { IEndRequestAction } from 'actions/response/basics';
 
 export interface IWebsocketMessage {
     direction: WSMsgDirection;
@@ -11,18 +12,78 @@ export interface IWebsocketMessage {
     content: string;
 }
 
-export type WS_State = OrderedSet<IWebsocketMessage>;
-const DEFAULT_WS_STATE: WS_State = OrderedSet();
+export interface IWebSocketConnection {
+    connected: boolean;
+    messages: OrderedSet<IWebsocketMessage>;
+}
 
-export default function reduceWebsocket(state = DEFAULT_WS_STATE, action: IWebsocketMessageLoggedAction) {
+const DEFAULT_WS_CONNECTION: IWebSocketConnection = {
+    connected: false,
+    messages: OrderedSet()
+};
+
+export type WebSocketAction = IWebsocketMessageLoggedAction | IEndRequestAction | IWebsocketDisconnectedAction;
+
+export type WS_State = Map<string, IWebSocketConnection>;
+const DEFAULT_WS_STATE: WS_State = Map();
+
+export default function reduceWebsocket(collection: WS_State = DEFAULT_WS_STATE, action: WebSocketAction) {
+    if (!action.requestId) {
+        return collection;
+    }
+    if (action.type === 'RESPONSE_END_REQUEST') {
+        let isConnectedWebsocket = false;
+        if (action.response?.statusCode === 101 && action.response?.headers) {
+            for (const header of action.response?.headers) {
+                if (header.key === "Upgrade" && header.value === "WebSocket"){
+                    isConnectedWebsocket = true;
+                    break;
+                }
+            }
+        }
+        if (!isConnectedWebsocket) {
+            return collection;
+        }
+        let reqId = action.requestId;
+        let state = collection.get(reqId);
+        if (!state) {
+            state = DEFAULT_WS_CONNECTION;
+        }
+        state = {
+            ...state,
+            connected: true
+        };
+        return collection.set(reqId, state);
+    }
     if (action.type === 'REQUEST_WEBSOCKET_MESSAGE_LOGGED') {
+        let reqId = action.requestId;
+        let state = collection.get(reqId);
+        if (!state) {
+            state = DEFAULT_WS_CONNECTION;
+        }
         const { direction, time, content } = action;
-        return state.add({
-            direction,
-            time,
-            content,
-        });
+        state = {
+            ...state,
+            messages: state.messages.add({
+                direction,
+                time,
+                content,
+            })
+        };
+        return collection.set(reqId, state);
+    }
+    if (action.type === 'REQUEST_WEBSOCKET_DISCONNECTED') {
+        let reqId = action.requestId;
+        let state = collection.get(reqId);
+        if (!state) {
+            state = DEFAULT_WS_CONNECTION;
+        }
+        state = {
+            ...state,
+            connected: false
+        };
+        return collection.set(reqId, state);
     }
 
-    return state;
+    return collection;
 }

--- a/packages/devtools-network-console/src/reducers/websocket/index.ts
+++ b/packages/devtools-network-console/src/reducers/websocket/index.ts
@@ -31,6 +31,7 @@ export default function reduceWebsocket(collection: WS_State = DEFAULT_WS_STATE,
     if (!action.requestId) {
         return collection;
     }
+    // TODO: make switch statement
     if (action.type === 'RESPONSE_END_REQUEST') {
         let isConnectedWebsocket = false;
         if (action.response?.statusCode === 101 && action.response?.headers) {
@@ -44,7 +45,7 @@ export default function reduceWebsocket(collection: WS_State = DEFAULT_WS_STATE,
         if (!isConnectedWebsocket) {
             return collection;
         }
-        let reqId = action.requestId;
+        const reqId = action.requestId;
         let state = collection.get(reqId);
         if (!state) {
             state = DEFAULT_WS_CONNECTION;
@@ -56,7 +57,7 @@ export default function reduceWebsocket(collection: WS_State = DEFAULT_WS_STATE,
         return collection.set(reqId, state);
     }
     if (action.type === 'REQUEST_WEBSOCKET_MESSAGE_LOGGED') {
-        let reqId = action.requestId;
+        const reqId = action.requestId;
         let state = collection.get(reqId);
         if (!state) {
             state = DEFAULT_WS_CONNECTION;

--- a/packages/devtools-network-console/src/ui/ResponseViewer/WebSocket.tsx
+++ b/packages/devtools-network-console/src/ui/ResponseViewer/WebSocket.tsx
@@ -8,10 +8,11 @@ import CommonStyles from 'ui/common-styles';
 import WebSocketMessage from './WebSocketMessage';
 import { Select, SelectOption, Button, ButtonAppearance } from '@microsoft/fast-components-react-msft';
 import { editor, KeyCode } from 'monaco-editor';
-import { sendWsMessage } from 'actions/websocket';
-import { useDispatch, useSelector } from 'react-redux';
+import { sendWsMessage, sendWsDisconnect } from 'actions/websocket';
+import { useDispatch, connect } from 'react-redux';
 import { IView } from 'store';
-import { WS_State } from 'reducers/websocket';
+import { IWebSocketConnection } from 'reducers/websocket';
+import { AppHost } from 'store/host';
 
 const CONTAINER_VIEW = css(CommonStyles.FULL_SIZE_NOT_SCROLLABLE, {
     display: 'grid',
@@ -31,6 +32,11 @@ const MESSAGES_CONTAINER_STYLE = css({
     justifyContent: 'flex-end',
     height: 'calc(100% - 5px)',
     paddingBottom: '5px',
+});
+const DISCONNECTED_STYLE = css({
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'center',
 });
 const COMMAND_BAR_STYLE = css({
     display: 'flex',
@@ -73,17 +79,23 @@ const BODY_CONTENT_TYPES = [{
     text: 'JavaScript',
 }];
 
-export interface IWebSocketViewProps {
+export interface IOwnProps {
     requestId: string;
 }
 
-export default function WebSocketView(props: IWebSocketViewProps) {
+interface IConnectedProps {
+    connection: IWebSocketConnection;
+}
+export type IWebSocketViewProps = IConnectedProps & IOwnProps;
+
+export function WebSocketView(props: IWebSocketViewProps) {
     const [toSend, setToSend] = useState('');
     const [format, setFormat] = useState('text');
     const dispatch = useDispatch();
-    const messages = useSelector<IView, WS_State>(v => v.websocket);
     const editorRef = useRef<editor.IStandaloneCodeEditor | null>();
- 
+    const messages = props.connection.messages;
+    const connected = props.connection.connected;
+
     function handleEditorDidMount(_: any, editor: editor.IStandaloneCodeEditor) {
         editorRef.current = editor;
         editor.onKeyDown(e => {
@@ -114,7 +126,9 @@ export default function WebSocketView(props: IWebSocketViewProps) {
                     </div>
                 </div>
             </div>
-            <div {...COMMAND_BAR_STYLE}>
+            {connected ?
+            (<div>
+                <div {...COMMAND_BAR_STYLE}>
                 <Select
                     placeholder="Content Type"
                     jssStyleSheet={{
@@ -134,22 +148,59 @@ export default function WebSocketView(props: IWebSocketViewProps) {
                         );
                     })}
                 </Select>
-                <Button appearance={ButtonAppearance.primary}>Disconnect</Button>
-            </div>
-            <div className="ht100 flxcol">
-                <MonacoEditor
-                    language={format}
-                    theme="light"
-                    value={toSend}
-                    onChange={(_e, newValue) => {
-                        setToSend(newValue!);
-                    }}
-                    editorDidMount={handleEditorDidMount}
-                    options={{
-                        automaticLayout: true,
-                    }}
-                    />
-            </div>
+                <Button
+                    appearance={ButtonAppearance.primary}
+                    disabled={!connected}
+                    onClick={e => {
+                        dispatch(sendWsDisconnect(props.requestId));
+                        e.stopPropagation();
+                        e.preventDefault();
+                    }}>Disconnect</Button>
+                </div>
+                <div className="ht100 flxcol">
+                    <MonacoEditor
+                        language={format}
+                        theme="light"
+                        value={toSend}
+                        onChange={(_e, newValue) => {
+                            setToSend(newValue!);
+                        }}
+                        editorDidMount={handleEditorDidMount}
+                        options={{
+                            automaticLayout: true,
+                        }}
+                        />
+                </div>
+            </div>): <NotConnected />}
         </div>
     );
 }
+
+function NotConnected() {
+    return (
+        <div {...DISCONNECTED_STYLE}>
+            Websocket disconnected! Resend the request to re-connect!
+        </div>
+    );
+}
+
+function mapStateToProps(state: IView, ownProps: IOwnProps): IConnectedProps {
+    const wsConnection = state.websocket.get(ownProps.requestId);
+    if (!wsConnection) {
+        AppHost.log({
+            message: 'Invariant failure, no WebSocketConnection for ID',
+            where: 'ConnectedWebSocketViewer:mapStateToProps',
+            state,
+            ownProps,
+            wsConnection,
+        });
+        throw new Error('Invariant failed: WebsocketConnection not found for given request ID');
+    }
+
+    return {
+        connection: wsConnection
+    };
+}
+
+export const ConnectedWebSocketViewer = connect(mapStateToProps)(WebSocketView);
+export default ConnectedWebSocketViewer;

--- a/packages/devtools-network-console/src/ui/ResponseViewer/WebSocket.tsx
+++ b/packages/devtools-network-console/src/ui/ResponseViewer/WebSocket.tsx
@@ -127,7 +127,7 @@ export function WebSocketView(props: IWebSocketViewProps) {
                 </div>
             </div>
             {connected ?
-            (<div>
+            (<>
                 <div {...COMMAND_BAR_STYLE}>
                 <Select
                     placeholder="Content Type"
@@ -171,7 +171,7 @@ export function WebSocketView(props: IWebSocketViewProps) {
                         }}
                         />
                 </div>
-            </div>): <NotConnected />}
+            </>): <NotConnected />}
         </div>
     );
 }

--- a/packages/devtools-network-console/src/ui/ResponseViewer/WebSocketMessage.tsx
+++ b/packages/devtools-network-console/src/ui/ResponseViewer/WebSocketMessage.tsx
@@ -41,7 +41,7 @@ export default function WebSocketMessage(props: WebSocketMessageProps) {
                             {message}
                         </code>
                     ) : (
-                        <JsonView 
+                        <JsonView
                             src={message}
                             displayDataTypes={false}
                             enableClipboard={false}
@@ -59,7 +59,7 @@ var MESSAGE_STYLE_BASE = css({
     width: '90%',
     display: 'grid',
     gridTemplateColumns: '85px auto',
-    borderRadius: '20px',
+    borderRadius: '4px',
     padding: '15px',
     marginTop: '5px',
 });

--- a/packages/devtools-network-console/src/ui/ResponseViewer/index.tsx
+++ b/packages/devtools-network-console/src/ui/ResponseViewer/index.tsx
@@ -51,7 +51,7 @@ const headersColumns: DataGridColumn[] = [
     },
 ];
 
-type ActivityState = 'preview' | 'body' | 'headers' | 'cookies';
+type ActivityState = 'preview' | 'body' | 'headers' | 'cookies' | 'websocket';
 const PIVOT_DEFAULT_ITEMS = [{
     tab: (cn: string) => <div className={cn}>Body</div>,
     content: () => <></>,
@@ -148,11 +148,14 @@ export function ResponseViewer(props: IResponseViewerProps) {
     const tabsToDisplay = PIVOT_DEFAULT_ITEMS.slice();
     if (!!renderedPreview) {
         tabsToDisplay.unshift(PIVOT_PREVIEW_ITEM);
+    } else if(currentTab === "preview") {
+        setCurrentTab('body');
     }
 
-    if (true || false) {
-        // TODO: Mock up the websocket connection
+    if (props.response.isWebsocketUpgrade) {
         tabsToDisplay.push(WEBSOCKET_ITEM);
+    } else if (currentTab === "websocket") {
+        setCurrentTab('body');
     }
 
     return (

--- a/packages/devtools-network-console/src/ui/ResponseViewer/index.tsx
+++ b/packages/devtools-network-console/src/ui/ResponseViewer/index.tsx
@@ -20,7 +20,7 @@ import ResponseBody from './ResponseBody';
 import ContainerWithStatusBar from 'ui/generic/ContainerWithStatusBar';
 import { HideUnless } from 'ui/generic/HideIf';
 import { DesignSystemProvider } from '@microsoft/fast-jss-manager-react';
-import ConnectedWebSocketViewer from './WebSocket';
+import WebSocketView from './WebSocket';
 
 interface IConnectedProps {
     response: INetConsoleResponseInternal;
@@ -148,13 +148,17 @@ export function ResponseViewer(props: IResponseViewerProps) {
     const tabsToDisplay = PIVOT_DEFAULT_ITEMS.slice();
     if (!!renderedPreview) {
         tabsToDisplay.unshift(PIVOT_PREVIEW_ITEM);
-    } else if(currentTab === "preview") {
+    } else if(currentTab === 'preview') {
+        // TODO: determine if necessary
+        // (this fixes bad webhost state if you send a different request that does not have a preview)
         setCurrentTab('body');
     }
 
     if (props.response.isWebsocketUpgrade) {
         tabsToDisplay.push(WEBSOCKET_ITEM);
-    } else if (currentTab === "websocket") {
+    } else if (currentTab === 'websocket') {
+        // TODO: determine if necessary
+        // (this fixes bad webhost state if you send a different request that does not have a websocket)
         setCurrentTab('body');
     }
 
@@ -199,7 +203,7 @@ export function ResponseViewer(props: IResponseViewerProps) {
                     </div>
                 </HideUnless>
                 <HideUnless test={currentTab} match="websocket" {...CommonStyles.SCROLL_CONTAINER_STYLE}>
-                    <ConnectedWebSocketViewer requestId={props.requestId} />
+                    <WebSocketView requestId={props.requestId} />
                 </HideUnless>
             </div>
 

--- a/packages/devtools-network-console/src/ui/ResponseViewer/index.tsx
+++ b/packages/devtools-network-console/src/ui/ResponseViewer/index.tsx
@@ -20,7 +20,7 @@ import ResponseBody from './ResponseBody';
 import ContainerWithStatusBar from 'ui/generic/ContainerWithStatusBar';
 import { HideUnless } from 'ui/generic/HideIf';
 import { DesignSystemProvider } from '@microsoft/fast-jss-manager-react';
-import WebSocketView from './WebSocket';
+import ConnectedWebSocketViewer from './WebSocket';
 
 interface IConnectedProps {
     response: INetConsoleResponseInternal;
@@ -199,7 +199,7 @@ export function ResponseViewer(props: IResponseViewerProps) {
                     </div>
                 </HideUnless>
                 <HideUnless test={currentTab} match="websocket" {...CommonStyles.SCROLL_CONTAINER_STYLE}>
-                    <WebSocketView requestId={props.requestId} />
+                    <ConnectedWebSocketViewer requestId={props.requestId} />
                 </HideUnless>
             </div>
 


### PR DESCRIPTION
PR that refactors WS state to associate a connection status and list of messages with a request id. Only shows WS tab when ws successfully upgrades connection. Adds new disconnect action and UI