### PR TITLE
Implementation of the WebSocket host protocol messages. 

### DIFF
--- a/packages/devtools-network-console/package-lock.json
+++ b/packages/devtools-network-console/package-lock.json
@@ -10863,11 +10863,6 @@
         "minimist": "^1.2.5"
       }
     },
-    "monaco-editor": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.19.3.tgz",
-      "integrity": "sha512-2n1vJBVQF2Hhi7+r1mMeYsmlf18hjVb6E0v5SoMZyb4aeOmYPKun+CE3gYpiNA1KEvtSdaDHFBqH9d7Wd9vREg=="
-    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",

--- a/packages/devtools-network-console/package.json
+++ b/packages/devtools-network-console/package.json
@@ -14,7 +14,6 @@
     "glamor": "^2.20.40",
     "immutable": "^4.0.0-rc.12",
     "lodash-es": "^4.17.15",
-    "monaco-editor": "^0.19.3",
     "network-console-shared": "../network-console-shared",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",

--- a/packages/devtools-network-console/src/actions/websocket/index.ts
+++ b/packages/devtools-network-console/src/actions/websocket/index.ts
@@ -6,6 +6,7 @@ import { ThunkAction } from 'redux-thunk';
 import { IView } from 'store';
 import { AnyAction } from 'redux';
 import { WebSocketMock } from 'host/web-application-host';
+import { AppHost } from 'store/host';
 
 export interface ISendWebsocketMessageAction {
     type: 'REQUEST_WEBSOCKET_SEND_MESSAGE';
@@ -59,12 +60,16 @@ export function makeWebSocketDisconnectedAction(requestId: string): IWebsocketDi
 export function sendWsMessage(requestId: string, messageBody: string): ThunkAction<void, IView, void, AnyAction> {
     return async dispatch => {
         dispatch(makeSendWebsocketMessageAction(requestId, messageBody));
-        WebSocketMock.instance(requestId).send(messageBody);
+        // WebSocketMock.instance(requestId).send(messageBody);
+
+        // TODO: Support base64?
+        AppHost.sendWebSocketMessage(requestId, messageBody, 'text');
     };
 }
 
 export function sendWsDisconnect(requestId: string): ThunkAction<void, IView, void, AnyAction> {
     return async dispatch => {
         dispatch(makeWebSocketDisconnectedAction(requestId));
+        AppHost.disconnectWebsocket(requestId);
     };
 }

--- a/packages/devtools-network-console/src/host/host-protocol.md
+++ b/packages/devtools-network-console/src/host/host-protocol.md
@@ -134,6 +134,29 @@ Logs some message via the message port. No response is expected to this.
 }
 ```
 
+### `DISCONNECT_WEBSOCKET`
+
+Disconnects a websocket for a given request.
+
+```ts
+{
+    type: 'DISCONNECT_WEBSOCKET';
+    requestId: string;
+}
+```
+
+### `WEBSOCKET_SEND_MESSAGE`
+
+Sends a message via a WebSocket.
+
+```ts
+{
+    type: 'WEBSOCKET_SEND_MESSAGE';
+    message: string | Base64String;
+    encoding: 'text' | 'base64';
+}
+```
+
 ## Host-to-Frontend
 
 ### `INIT_HOST`
@@ -290,5 +313,31 @@ Closes a view.
 {
     type: 'CLOSE_VIEW';
     requestId: string;
+}
+```
+
+### `WEBSOCKET_DISCONNECTED`
+
+Notifies the frontend that a websocket associated with a particular request has been disconnected,
+either because of a user request or an error.
+
+```ts
+{
+    type: 'WEBSOCKET_DISCONNECTED';
+    requestId: string;
+    error?: string;
+}
+```
+
+### `WEBSOCKET_PACKET`
+
+Notifies the frontend that a WebSocket packet has been observed.
+
+```ts
+{
+    type: 'WEBSOCKET_PACKET';
+    data: string | Base64String;
+    encoding: 'text' | 'base64';
+    direction: 'send' | 'recv';
 }
 ```

--- a/packages/devtools-network-console/src/host/interfaces.ts
+++ b/packages/devtools-network-console/src/host/interfaces.ts
@@ -71,4 +71,14 @@ export interface INetConsoleHost {
     openUnattachedRequest: (requestId: string) => void;
 
     log: (message: object) => void;
+
+    /**
+     * If a connection has been upgraded to a WebSocket, allows it to be disconnected.
+     */
+    disconnectWebsocket: (requestId: string) => void;
+    /**
+     * If a connection has been upgraded to a WebSocket, sends a message. The default value of
+     * the `encoding` parameter is 'text'.
+     */
+    sendWebSocketMessage: (requestId: string, message: string, encoding?: 'text' | 'base64') => void;
 }

--- a/packages/devtools-network-console/src/host/vscode-protocol-host.ts
+++ b/packages/devtools-network-console/src/host/vscode-protocol-host.ts
@@ -23,6 +23,8 @@ import {
     IUpdateEnvironmentMessage,
     ICloseViewMessage,
     IShowViewMessage,
+    IWebSocketDisconnectedMessage,
+    IWebSocketPacketMessage,
 } from 'network-console-shared/hosting/host-messages';
 
 import { INetConsoleHost, ISaveResult } from './interfaces';
@@ -315,6 +317,14 @@ export default class VsCodeProtocolHost implements INetConsoleHost {
         globalDispatch(closeViewAction(message.requestId));
     }
 
+    protected onWebSocketDisconnected(message: IWebSocketDisconnectedMessage) {
+        // TODO: Connect the host message to the global dispatcher
+    }
+
+    protected onWebSocketPacket(message: IWebSocketPacketMessage) {
+        // TODO: Connect the host message to the global dispatcher
+    }
+
     public mustAskToOpenLink = () => true;
     public openLink(url: string) {
         this.sendMessage({
@@ -342,6 +352,29 @@ export default class VsCodeProtocolHost implements INetConsoleHost {
         this.sendMessage({
             type: 'LOG',
             ...message,
+        });
+    }
+
+    /**
+     * If a connection has been upgraded to a WebSocket, allows it to be disconnected.
+     */
+    disconnectWebsocket(requestId: string) {
+        this.sendMessage({
+            type: 'DISCONNECT_WEBSOCKET',
+            requestId,
+        });
+    }
+
+    /**
+     * If a connection has been upgraded to a WebSocket, sends a message. The default value of
+     * the `encoding` parameter is 'text'.
+     */
+    sendWebSocketMessage(requestId: string, message: string, encoding: 'text' | 'base64' = 'text') {
+        this.sendMessage({
+            type: 'WEBSOCKET_SEND_MESSAGE',
+            encoding,
+            message,
+            requestId,
         });
     }
 }

--- a/packages/devtools-network-console/src/host/vscode-protocol-host.ts
+++ b/packages/devtools-network-console/src/host/vscode-protocol-host.ts
@@ -227,6 +227,14 @@ export default class VsCodeProtocolHost implements INetConsoleHost {
             case 'SHOW_OPEN_REQUEST':
                 this.onShowView(message);
                 break;
+
+            case 'WEBSOCKET_DISCONNECTED':
+                this.onWebSocketDisconnected(message);
+                break;
+
+            case 'WEBSOCKET_PACKET':
+                this.onWebSocketPacket(message);
+                break;
         }
     }
 
@@ -379,8 +387,6 @@ export default class VsCodeProtocolHost implements INetConsoleHost {
             message,
             requestId,
         });
-        // TODO: need to wait for the response so we can establish timing
-        globalDispatch(makeWebsocketMessageLoggedAction(requestId, 'send', 0, message));
     }
 }
 

--- a/packages/devtools-network-console/src/host/vscode-protocol-host.ts
+++ b/packages/devtools-network-console/src/host/vscode-protocol-host.ts
@@ -46,6 +46,7 @@ import {
     ID_DIV_ROUTE,
 } from 'reducers/request/id-manager';
 import { chooseViewAction, closeViewAction } from 'actions/view-manager';
+import { makeWebsocketMessageLoggedAction, makeWebSocketDisconnectedAction } from 'actions/websocket';
 
 type PostMessage = (msg: any) => void;
 type HandleMessage = (ev: MessageEvent) => void;
@@ -319,10 +320,12 @@ export default class VsCodeProtocolHost implements INetConsoleHost {
 
     protected onWebSocketDisconnected(message: IWebSocketDisconnectedMessage) {
         // TODO: Connect the host message to the global dispatcher
+        globalDispatch(makeWebSocketDisconnectedAction(message.requestId));
     }
 
     protected onWebSocketPacket(message: IWebSocketPacketMessage) {
-        // TODO: Connect the host message to the global dispatcher
+        // TODO: Establish timing
+        globalDispatch(makeWebsocketMessageLoggedAction(message.requestId, message.direction, 0, message.data));
     }
 
     public mustAskToOpenLink = () => true;
@@ -376,6 +379,8 @@ export default class VsCodeProtocolHost implements INetConsoleHost {
             message,
             requestId,
         });
+        // TODO: need to wait for the response so we can establish timing
+        globalDispatch(makeWebsocketMessageLoggedAction(requestId, 'send', 0, message));
     }
 }
 

--- a/packages/devtools-network-console/src/host/web-application-host.ts
+++ b/packages/devtools-network-console/src/host/web-application-host.ts
@@ -128,6 +128,21 @@ export default class WebApplicationHost implements INetConsoleHost {
             ...message,
         });
     }
+
+    /**
+     * If a connection has been upgraded to a WebSocket, allows it to be disconnected.
+     */
+    disconnectWebsocket(_requestId: string) {
+        // TODO: Do something here?
+    }
+
+    /**
+     * If a connection has been upgraded to a WebSocket, sends a message. The default value of
+     * the `encoding` parameter is 'text'.
+     */
+    sendWebSocketMessage(_requestId: string, _message: string, _encoding: 'text' | 'base64' = 'text') {
+        // TODO: Do something here?
+    }
 }
 
 function constructHeaders(request: IHttpRequest): Headers {

--- a/packages/devtools-network-console/src/ui/ResponseViewer/WebSocket.tsx
+++ b/packages/devtools-network-console/src/ui/ResponseViewer/WebSocket.tsx
@@ -84,7 +84,7 @@ export interface IOwnProps {
 }
 
 interface IConnectedProps {
-    connection: IWebSocketConnection;
+    connection?: IWebSocketConnection;
 }
 export type IWebSocketViewProps = IConnectedProps & IOwnProps;
 
@@ -101,8 +101,8 @@ export function WebSocketView(props: IWebSocketViewProps) {
     const [format, setFormat] = useState('text');
     const dispatch = useDispatch();
     const editorRef = useRef<editor.IStandaloneCodeEditor | null>();
-    const messages = props.connection.messages;
-    const connected = props.connection.connected;
+    const messages = props.connection?.messages;
+    const connected = props.connection?.connected;
 
     function handleEditorDidMount(_: any, monacoInstance: editor.IStandaloneCodeEditor) {
         editorRef.current = monacoInstance;
@@ -114,6 +114,14 @@ export function WebSocketView(props: IWebSocketViewProps) {
                 e.stopPropagation();
             }
         });
+    }
+
+    if (!messages || !connected) {
+        return (
+            <div {...CONTAINER_VIEW}>
+                <h4>No WebSocket found for this request-response pair.</h4>
+            </div>
+        );
     }
 
     return (
@@ -194,17 +202,6 @@ function NotConnected() {
 
 function mapStateToProps(state: IView, ownProps: IOwnProps): IConnectedProps {
     const wsConnection = state.websocket.get(ownProps.requestId);
-    if (!wsConnection) {
-        AppHost.log({
-            message: 'Invariant failure, no WebSocketConnection for ID',
-            where: 'ConnectedWebSocketViewer:mapStateToProps',
-            state,
-            ownProps,
-            wsConnection,
-        });
-        throw new Error('Invariant failed: WebsocketConnection not found for given request ID');
-    }
-
     return {
         connection: wsConnection
     };

--- a/packages/devtools-network-console/src/ui/ResponseViewer/WebSocket.tsx
+++ b/packages/devtools-network-console/src/ui/ResponseViewer/WebSocket.tsx
@@ -7,7 +7,6 @@ import { ControlledEditor as MonacoEditor } from '@monaco-editor/react';
 import CommonStyles from 'ui/common-styles';
 import WebSocketMessage from './WebSocketMessage';
 import { Select, SelectOption, Button, ButtonAppearance } from '@microsoft/fast-components-react-msft';
-// import { editor, KeyCode } from 'monaco-editor';
 import { sendWsMessage, sendWsDisconnect } from 'actions/websocket';
 import { useDispatch, connect } from 'react-redux';
 import { IView } from 'store';

--- a/packages/devtools-network-console/src/ui/ResponseViewer/WebSocket.tsx
+++ b/packages/devtools-network-console/src/ui/ResponseViewer/WebSocket.tsx
@@ -12,7 +12,6 @@ import { sendWsMessage, sendWsDisconnect } from 'actions/websocket';
 import { useDispatch, connect } from 'react-redux';
 import { IView } from 'store';
 import { IWebSocketConnection } from 'reducers/websocket';
-import { AppHost } from 'store/host';
 
 const CONTAINER_VIEW = css(CommonStyles.FULL_SIZE_NOT_SCROLLABLE, {
     display: 'grid',

--- a/packages/devtools-network-console/src/ui/ResponseViewer/WebSocket.tsx
+++ b/packages/devtools-network-console/src/ui/ResponseViewer/WebSocket.tsx
@@ -7,7 +7,7 @@ import { ControlledEditor as MonacoEditor } from '@monaco-editor/react';
 import CommonStyles from 'ui/common-styles';
 import WebSocketMessage from './WebSocketMessage';
 import { Select, SelectOption, Button, ButtonAppearance } from '@microsoft/fast-components-react-msft';
-import { editor, KeyCode } from 'monaco-editor';
+// import { editor, KeyCode } from 'monaco-editor';
 import { sendWsMessage, sendWsDisconnect } from 'actions/websocket';
 import { useDispatch, connect } from 'react-redux';
 import { IView } from 'store';
@@ -88,6 +88,14 @@ interface IConnectedProps {
 }
 export type IWebSocketViewProps = IConnectedProps & IOwnProps;
 
+// The 'monaco-editor' package would be used for type checking, but it's not really
+// necessary, and if we actually import it, what ends up happening is that it blows up
+// the build output size. This declaration avoids it to avoid the following import:
+//     import { editor, KeyCode } from 'monaco-editor';
+declare namespace editor {
+    type IStandaloneCodeEditor = any;
+}
+
 export function WebSocketView(props: IWebSocketViewProps) {
     const [toSend, setToSend] = useState('');
     const [format, setFormat] = useState('text');
@@ -96,10 +104,10 @@ export function WebSocketView(props: IWebSocketViewProps) {
     const messages = props.connection.messages;
     const connected = props.connection.connected;
 
-    function handleEditorDidMount(_: any, editor: editor.IStandaloneCodeEditor) {
-        editorRef.current = editor;
-        editor.onKeyDown(e => {
-            if (e.keyCode === KeyCode.Enter && e.ctrlKey) {
+    function handleEditorDidMount(_: any, monacoInstance: editor.IStandaloneCodeEditor) {
+        editorRef.current = monacoInstance;
+        monacoInstance.onKeyDown((e: any) => {
+            if (e.keyCode === /* KeyCode.Enter */ 3 && e.ctrlKey) {
                 dispatch(sendWsMessage(props.requestId, editorRef.current!.getValue()));
                 setToSend('');
                 e.preventDefault();

--- a/packages/network-console-shared/src/hosting/frontend-messages.ts
+++ b/packages/network-console-shared/src/hosting/frontend-messages.ts
@@ -3,6 +3,7 @@
 
 import { IHttpRequest } from '../net/http-base';
 import { INetConsoleRequest, INetConsoleAuthorization, INetConsoleParameter } from '../net/net-console-http';
+import { Base64String } from '../util/base64';
 
 interface IMessage<T extends string> {
     type: T;
@@ -52,6 +53,16 @@ export interface IOpenUnattachedRequestMessage extends IMessage<'OPEN_NEW_UNATTA
     requestId: string;
 }
 
+export interface IDisconnectWebSocketMessage extends IMessage<'DISCONNECT_WEBSOCKET'> {
+    requestId: string;
+}
+
+export interface ISendWebSocketMessage extends IMessage<'WEBSOCKET_SEND_MESSAGE'> {
+    requestId: string;
+    message: string | Base64String;
+    encoding: 'text' | 'base64';
+}
+
 export type ILogMessage = IMessage<'LOG'> & {
     [s: string]: any;
 };
@@ -65,5 +76,7 @@ export type FrontendMessage =
     IOpenWebLinkMessage |
     IOpenUnattachedRequestMessage |
     IUpdateDirtyFlagMessage |
-    ILogMessage
+    ILogMessage |
+    IDisconnectWebSocketMessage |
+    ISendWebSocketMessage
     ;

--- a/packages/network-console-shared/src/hosting/host-messages.ts
+++ b/packages/network-console-shared/src/hosting/host-messages.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { INetConsoleRequest, INetConsoleAuthorization, INetConsoleResponse, INetConsoleParameter } from '../net/net-console-http';
+import { Base64String } from '../util/base64';
 
 interface IMessage<T extends string> {
     type: T;
@@ -100,6 +101,17 @@ export interface IShowViewMessage extends IMessage<'SHOW_OPEN_REQUEST'> {
 
 export type IClearEnvironmentMessage = IMessage<'CLEAR_ENVIRONMENT'>;
 
+export interface IWebSocketDisconnectedMessage extends IMessage<'WEBSOCKET_DISCONNECTED'> {
+    requestId: string;
+}
+
+export interface IWebSocketPacketMessage extends IMessage<'WEBSOCKET_PACKET'> {
+    requestId: string;
+    data: string | Base64String;
+    direction: 'send' | 'recv';
+    encoding: 'text' | 'base64';
+}
+
 export type HostMessage =
     IInitHostMessage |
     IInitEmptyRequestMessage |
@@ -113,5 +125,7 @@ export type HostMessage =
     IEditEnvironmentMessage |
     IUpdateEnvironmentMessage |
     ICloseViewMessage |
-    IShowViewMessage
+    IShowViewMessage |
+    IWebSocketDisconnectedMessage |
+    IWebSocketPacketMessage
     ;


### PR DESCRIPTION
Supercedes #16 

This change implements the WebSocket host protocol definition against the Hackathon topic branch `hackathon-2020`. There's still a lot of `TODO` around, but it gives a baseline against which we can hook up an informed host.