### PR TITLE
Only expand top-level namespace for JSON objects

### DIFF
--- a/packages/devtools-network-console/src/ui/ResponseViewer/WebSocketMessage.tsx
+++ b/packages/devtools-network-console/src/ui/ResponseViewer/WebSocketMessage.tsx
@@ -47,6 +47,9 @@ export default function WebSocketMessage(props: WebSocketMessageProps) {
                             enableClipboard={false}
                             iconStyle="triangle"
                             theme="shapeshifter:inverted"
+                            shouldCollapse={cfp => {
+                                return cfp.namespace.length > 1;
+                            }}
                             />
                     ))
                 }


### PR DESCRIPTION
This prevents complex objects from being displayed beyond their top-level view by default.

![image](https://user-images.githubusercontent.com/1490290/88708411-76007700-d0c8-11ea-97f2-47fef70e398b.png)
