### PR TITLE
Add Dark Theme support, change message text size and layout

### DIFF
--- a/packages/devtools-network-console/src/actions/websocket/index.ts
+++ b/packages/devtools-network-console/src/actions/websocket/index.ts
@@ -60,16 +60,16 @@ export function makeWebSocketDisconnectedAction(requestId: string): IWebsocketDi
 export function sendWsMessage(requestId: string, messageBody: string): ThunkAction<void, IView, void, AnyAction> {
     return async dispatch => {
         dispatch(makeSendWebsocketMessageAction(requestId, messageBody));
-        WebSocketMock.instance(requestId).send(messageBody);
+        // WebSocketMock.instance(requestId).send(messageBody);
 
         // TODO: Support base64?
-        // AppHost.sendWebSocketMessage(requestId, messageBody, 'text');
+        AppHost.sendWebSocketMessage(requestId, messageBody, 'text');
     };
 }
 
 export function sendWsDisconnect(requestId: string): ThunkAction<void, IView, void, AnyAction> {
     return async dispatch => {
         dispatch(makeWebSocketDisconnectedAction(requestId));
-        // AppHost.disconnectWebsocket(requestId);
+        AppHost.disconnectWebsocket(requestId);
     };
 }

--- a/packages/devtools-network-console/src/actions/websocket/index.ts
+++ b/packages/devtools-network-console/src/actions/websocket/index.ts
@@ -60,16 +60,16 @@ export function makeWebSocketDisconnectedAction(requestId: string): IWebsocketDi
 export function sendWsMessage(requestId: string, messageBody: string): ThunkAction<void, IView, void, AnyAction> {
     return async dispatch => {
         dispatch(makeSendWebsocketMessageAction(requestId, messageBody));
-        // WebSocketMock.instance(requestId).send(messageBody);
+        WebSocketMock.instance(requestId).send(messageBody);
 
         // TODO: Support base64?
-        AppHost.sendWebSocketMessage(requestId, messageBody, 'text');
+        // AppHost.sendWebSocketMessage(requestId, messageBody, 'text');
     };
 }
 
 export function sendWsDisconnect(requestId: string): ThunkAction<void, IView, void, AnyAction> {
     return async dispatch => {
         dispatch(makeWebSocketDisconnectedAction(requestId));
-        AppHost.disconnectWebsocket(requestId);
+        // AppHost.disconnectWebsocket(requestId);
     };
 }

--- a/packages/devtools-network-console/src/actions/websocket/index.ts
+++ b/packages/devtools-network-console/src/actions/websocket/index.ts
@@ -5,7 +5,6 @@ import { ms } from 'network-console-shared';
 import { ThunkAction } from 'redux-thunk';
 import { IView } from 'store';
 import { AnyAction } from 'redux';
-import { WebSocketMock } from 'host/web-application-host';
 import { AppHost } from 'store/host';
 
 export interface ISendWebsocketMessageAction {

--- a/packages/devtools-network-console/src/host/web-application-host.ts
+++ b/packages/devtools-network-console/src/host/web-application-host.ts
@@ -37,7 +37,7 @@ export default class WebApplicationHost implements INetConsoleHost {
             ));
             globalDispatch(setHostOptionsAction(true));
             globalDispatch(loadRequestAction('DEFAULT_REQUEST', DEFAULT_NET_CONSOLE_REQUEST));
-            recalculateAndApplyTheme('', 'light');
+            recalculateAndApplyTheme('', 'dark');
         }, 1000);
         (window as any).__debug_WAH = this;
     }

--- a/packages/devtools-network-console/src/host/web-application-host.ts
+++ b/packages/devtools-network-console/src/host/web-application-host.ts
@@ -140,8 +140,8 @@ export default class WebApplicationHost implements INetConsoleHost {
      * If a connection has been upgraded to a WebSocket, sends a message. The default value of
      * the `encoding` parameter is 'text'.
      */
-    sendWebSocketMessage(_requestId: string, _message: string, _encoding: 'text' | 'base64' = 'text') {
-        // TODO: Do something here?
+    sendWebSocketMessage(requestId: string, message: string, _encoding: 'text' | 'base64' = 'text') {
+        WebSocketMock.instance(requestId).send(message);
     }
 }
 

--- a/packages/devtools-network-console/src/ui/ResponseViewer/WebSocket.tsx
+++ b/packages/devtools-network-console/src/ui/ResponseViewer/WebSocket.tsx
@@ -43,6 +43,9 @@ const COMMAND_BAR_STYLE = css({
     flexDirection: 'row',
     justifyContent: 'center',
 });
+const COMMAND_BAR_BUTTON_STYLE = css({
+    marginLeft: '5px'
+});
 
 const BODY_CONTENT_TYPES = [{
     key: 'text',
@@ -154,42 +157,46 @@ export function WebSocketView(props: IWebSocketViewProps) {
             {connected ?
             (<>
                 <div {...COMMAND_BAR_STYLE}>
-                <Select
-                    placeholder="Content Type"
-                    jssStyleSheet={{
-                        select: {
-                            width: '205px',
-                            zIndex: '500',
-                            position: 'relative',
-                        },
-                    }}
-                    onMenuSelectionChange={items => {
-                        const item = items[0]!;
-                        setFormat(item.id);
-                    }}>
-                    {BODY_CONTENT_TYPES.map(item => {
-                        return (
-                            <SelectOption key={item.key} id={item.key} value={item.text} title={item.text} displayString={item.text} />
-                        );
-                    })}
-                </Select>
-                <Button
-                    appearance={ButtonAppearance.primary}
-                    disabled={!connected || !editorRef.current || editorRef.current!.getValue() === ''}
-                    onClick={e => {
-                        dispatch(sendWsMessage(props.requestId, editorRef.current!.getValue()));
-                        setToSend('');
-                        e.stopPropagation();
-                        e.preventDefault();
-                    }}>Send</Button>
-                <Button
-                    appearance={ButtonAppearance.outline}
-                    disabled={!connected}
-                    onClick={e => {
-                        dispatch(sendWsDisconnect(props.requestId));
-                        e.stopPropagation();
-                        e.preventDefault();
-                    }}>Disconnect</Button>
+                    <Select
+                        placeholder="Content Type"
+                        jssStyleSheet={{
+                            select: {
+                                width: '300px',
+                                zIndex: '500',
+                                position: 'relative',
+                            },
+                        }}
+                        onMenuSelectionChange={items => {
+                            const item = items[0]!;
+                            setFormat(item.id);
+                        }}>
+                        {BODY_CONTENT_TYPES.map(item => {
+                            return (
+                                <SelectOption key={item.key} id={item.key} value={item.text} title={item.text} displayString={item.text} />
+                            );
+                        })}
+                    </Select>
+                    <div {...COMMAND_BAR_BUTTON_STYLE}>
+                        <Button
+                            appearance={ButtonAppearance.primary}
+                            disabled={!connected || !editorRef.current || editorRef.current!.getValue() === ''}
+                            onClick={e => {
+                                dispatch(sendWsMessage(props.requestId, editorRef.current!.getValue()));
+                                setToSend('');
+                                e.stopPropagation();
+                                e.preventDefault();
+                            }}>Send</Button>
+                    </div>
+                    <div {...COMMAND_BAR_BUTTON_STYLE}>
+                        <Button
+                            appearance={ButtonAppearance.outline}
+                            disabled={!connected}
+                            onClick={e => {
+                                dispatch(sendWsDisconnect(props.requestId));
+                                e.stopPropagation();
+                                e.preventDefault();
+                            }}>Disconnect</Button>
+                    </div>
                 </div>
                 <div className="ht100 flxcol">
                     <MonacoEditor

--- a/packages/devtools-network-console/src/ui/ResponseViewer/WebSocket.tsx
+++ b/packages/devtools-network-console/src/ui/ResponseViewer/WebSocket.tsx
@@ -11,6 +11,7 @@ import { sendWsMessage, sendWsDisconnect } from 'actions/websocket';
 import { useDispatch, connect } from 'react-redux';
 import { IView } from 'store';
 import { IWebSocketConnection } from 'reducers/websocket';
+import { THEME_TYPE } from 'themes/vscode-theme';
 
 const CONTAINER_VIEW = css(CommonStyles.FULL_SIZE_NOT_SCROLLABLE, {
     display: 'grid',
@@ -30,6 +31,7 @@ const MESSAGES_CONTAINER_STYLE = css({
     flexDirection: 'column',
     justifyContent: 'flex-end',
     paddingBottom: '5px',
+    marginRight: '10px',
 });
 const DISCONNECTED_STYLE = css({
     display: 'flex',
@@ -65,6 +67,7 @@ const BODY_CONTENT_TYPES = [{
 
 export interface IOwnProps {
     requestId: string;
+    theme: THEME_TYPE;
 }
 
 interface IConnectedProps {
@@ -191,7 +194,7 @@ export function WebSocketView(props: IWebSocketViewProps) {
                 <div className="ht100 flxcol">
                     <MonacoEditor
                         language={format}
-                        theme="light"
+                        theme={props.theme}
                         value={toSend}
                         onChange={(_e, newValue) => {
                             setToSend(newValue!);

--- a/packages/devtools-network-console/src/ui/ResponseViewer/WebSocketMessage.tsx
+++ b/packages/devtools-network-console/src/ui/ResponseViewer/WebSocketMessage.tsx
@@ -4,6 +4,8 @@
 import React, { useMemo } from 'react';
 import JsonView from 'react-json-view';
 import { css } from 'glamor';
+import { useSelector } from 'react-redux';
+import { IView, IThemeInfo } from 'store';
 
 interface WebSocketMessageProps {
     dir: 'send' | 'recv' | 'status';
@@ -12,21 +14,23 @@ interface WebSocketMessageProps {
 }
 
 export default function WebSocketMessage(props: WebSocketMessageProps) {
+    const themeType = useSelector<IView, IThemeInfo>(s => s.theme);
+    const applyDark = themeType.theme === 'dark';
     let isStatus = false;
     let arrow;
     let style;
     switch(props.dir) {
         case 'recv':
             arrow = <>&darr;</>;
-            style = MESSAGE_STYLE_RECV;
+            style = applyDark? MESSAGE_STYLE_RECV_DARK : MESSAGE_STYLE_RECV;
             break;
         case 'send':
             arrow = <>&uarr;</>;
-            style = MESSAGE_STYLE_SEND;
+            style = applyDark? MESSAGE_STYLE_SEND_DARK : MESSAGE_STYLE_SEND;
             break;
         case 'status':
         default:
-            style = MESSAGE_STYLE_STATUS;
+            style = applyDark ? MESSAGE_STYLE_STATUS_DARK : MESSAGE_STYLE_STATUS;
             isStatus = true;
             break;
     }
@@ -58,7 +62,7 @@ export default function WebSocketMessage(props: WebSocketMessageProps) {
                             displayDataTypes={false}
                             enableClipboard={false}
                             iconStyle="triangle"
-                            theme="shapeshifter:inverted"
+                            theme={applyDark ? "shapeshifter" : "shapeshifter:inverted"}
                             shouldCollapse={cfp => {
                                 return cfp.namespace.length > 1;
                             }}
@@ -71,12 +75,16 @@ export default function WebSocketMessage(props: WebSocketMessageProps) {
 }
 
 var MESSAGE_STYLE_BASE = css({
-    width: '90%',
+    minWidth: '15%',
+    maxWidth: '80%',
     display: 'grid',
-    gridTemplateColumns: '85px auto',
+        // flexDirection: 'column',
+    gridTemplateRows: '20px auto',
     borderRadius: '4px',
-    padding: '15px',
+    padding: '5px',
     marginTop: '5px',
+    fontSize: '12px',
+    overflowWrap: 'break-word',
 });
 
 var MESSAGE_STYLE_RECV = css(MESSAGE_STYLE_BASE, {
@@ -90,23 +98,36 @@ var MESSAGE_STYLE_SEND = css(MESSAGE_STYLE_BASE, {
 });
 
 var MESSAGE_STYLE_STATUS = css(MESSAGE_STYLE_BASE, {
-    width: '95%',
+    maxWidth: '100%',
+    alignSelf: 'stretch',
     backgroundColor: '#ddd',
 });
 
 var DESCRIPTOR_STYLE = css({
     display: 'flex',
-    flexDirection: 'column',
-    justifyContent: 'center',
+    flexDirection: 'row',
+    justifyContent: 'start',
     alignItems: 'center',
-    paddingRight: '15px',
 });
 
 var TIMER_STYLE = css({
     fontSize: '10px',
+    paddingLeft: '5px',
 });
 
 var ARROW_STYLE = css({
-    fontSize: '24px',
+    fontSize: '12px',
     fontWeight: 'bolder',
+});
+
+var MESSAGE_STYLE_RECV_DARK = css(MESSAGE_STYLE_RECV, {
+    backgroundColor: '#353',
+});
+
+var MESSAGE_STYLE_SEND_DARK = css(MESSAGE_STYLE_SEND, {
+    backgroundColor: '#335',
+});
+
+var MESSAGE_STYLE_STATUS_DARK = css(MESSAGE_STYLE_STATUS, {
+    backgroundColor: '#333',
 });

--- a/packages/devtools-network-console/src/ui/ResponseViewer/WebSocketMessage.tsx
+++ b/packages/devtools-network-console/src/ui/ResponseViewer/WebSocketMessage.tsx
@@ -50,13 +50,15 @@ export default function WebSocketMessage(props: WebSocketMessageProps) {
                 <div {...ARROW_STYLE}>{arrow}</div>
                 {(props.time !== undefined) && <div {...TIMER_STYLE}>{props.time}ms</div>}
             </div>}
-            <div className="json-view-with-transparent-background">
-                {
-                    (kind === 'text' ? (
+            {
+                (kind === 'text' ? (
+                    <div className="json-view-with-transparent-background">
                         <code>
                             {message}
                         </code>
-                    ) : (
+                    </div>
+                ) : (
+                    <div>
                         <JsonView
                             src={message}
                             displayDataTypes={false}
@@ -66,10 +68,10 @@ export default function WebSocketMessage(props: WebSocketMessageProps) {
                             shouldCollapse={cfp => {
                                 return cfp.namespace.length > 1;
                             }}
-                            />
-                    ))
-                }
-            </div>
+                        />
+                    </div>)
+                )
+            }
         </div>
     );
 }

--- a/packages/devtools-network-console/src/ui/ResponseViewer/index.tsx
+++ b/packages/devtools-network-console/src/ui/ResponseViewer/index.tsx
@@ -203,7 +203,7 @@ export function ResponseViewer(props: IResponseViewerProps) {
                     </div>
                 </HideUnless>
                 <HideUnless test={currentTab} match="websocket" {...CommonStyles.SCROLL_CONTAINER_STYLE}>
-                    <WebSocketView requestId={props.requestId} />
+                    <WebSocketView requestId={props.requestId} theme={props.theme}/>
                 </HideUnless>
             </div>
 


### PR DESCRIPTION
This PR updates the websocket page to respond to dark theme. It also updates the message bubbles with smaller text and direction indicators to better fit in smaller devtools instances. Layout is loosely inspired by MSFT Teams chat thread windows

![lightUpdate](https://user-images.githubusercontent.com/42152559/88727417-76a70680-d0e4-11ea-8e84-f9bfcaf1acb8.jpg)
![darkUpdate](https://user-images.githubusercontent.com/42152559/88727418-7870ca00-d0e4-11ea-82f0-a4710e677eaf.jpg)
