### PR TITLE
Targeted perf improvements

### DIFF
--- a/packages/devtools-network-console/src/reducers/websocket/index.ts
+++ b/packages/devtools-network-console/src/reducers/websocket/index.ts
@@ -9,6 +9,7 @@ import { IEndRequestAction } from 'actions/response/basics';
 export interface IWebsocketMessage {
     direction: WSMsgDirection;
     content: string;
+    entryNumber: number;
     time?: ms;
     reason?: string;
     error?: string;
@@ -58,6 +59,7 @@ export default function reduceWebsocket(collection: WS_State = DEFAULT_WS_STATE,
             messages: state.messages.add({
                 direction: 'status',
                 content: 'Connected',
+                entryNumber: state.messages.count(),
             })
         };
         return collection.set(reqId, state);
@@ -75,6 +77,7 @@ export default function reduceWebsocket(collection: WS_State = DEFAULT_WS_STATE,
                 direction,
                 time,
                 content,
+                entryNumber: state.messages.count(),
             })
         };
         return collection.set(reqId, state);
@@ -92,6 +95,7 @@ export default function reduceWebsocket(collection: WS_State = DEFAULT_WS_STATE,
             messages: state.messages.add({
                 direction: 'status',
                 content: 'Disconnected',
+                entryNumber: state.messages.count(),
             })
         };
         return collection.set(reqId, state);


### PR DESCRIPTION
This change implements targeted perf improvements when the number of messages in the WebSocketView is high. This is
because React would render all the WebSocketMessage components beneath.

Additionally, to improve testability and profiling, this implements a pretty lame "real WebSocket" connection in the
WebApplicationHost. However, it's pretty unusable, unless someone adds a `connect-src:` declaration to the CSP
definition in the index.html file.