### PR TITLE
Create the Websocket Connected host message and add disconnection reasons

### DIFF
--- a/packages/devtools-network-console/src/actions/combined.ts
+++ b/packages/devtools-network-console/src/actions/combined.ts
@@ -14,7 +14,7 @@ import { beginResponseAction, endResponseAction } from './response/basics';
 import downloadFile from 'utility/download';
 import { IView } from 'store';
 import { INetConsoleRequestInternal } from 'model/NetConsoleRequest';
-import { makeWebSocketClearMessagesAction } from './websocket';
+import { makeWebSocketClearMessagesAction, makeWebSocketDisconnectedAction } from './websocket';
 
 type Thaction = ThunkAction<void, IView, void, any>;
 export function executeRequest(requestId: string, request: INetConsoleRequestInternal, isDownloadForResponse: boolean, environmentalAuthorization: INetConsoleAuthorization | null = null): Thaction {
@@ -24,6 +24,7 @@ export function executeRequest(requestId: string, request: INetConsoleRequestInt
         dispatch(startRequestAction(requestId));
         dispatch(beginResponseAction(requestId));
         if (!request.url.startsWith('ws://') && !request.url.startsWith('wss://')) {
+            // dispatch(makeWebSocketDisconnectedAction(requestId));
             dispatch(makeWebSocketClearMessagesAction(requestId));
         }
 

--- a/packages/devtools-network-console/src/actions/combined.ts
+++ b/packages/devtools-network-console/src/actions/combined.ts
@@ -14,7 +14,7 @@ import { beginResponseAction, endResponseAction } from './response/basics';
 import downloadFile from 'utility/download';
 import { IView } from 'store';
 import { INetConsoleRequestInternal } from 'model/NetConsoleRequest';
-import { makeWebSocketClearMessagesAction, makeWebSocketDisconnectedAction } from './websocket';
+import { makeWebSocketClearMessagesAction } from './websocket';
 
 type Thaction = ThunkAction<void, IView, void, any>;
 export function executeRequest(requestId: string, request: INetConsoleRequestInternal, isDownloadForResponse: boolean, environmentalAuthorization: INetConsoleAuthorization | null = null): Thaction {

--- a/packages/devtools-network-console/src/actions/combined.ts
+++ b/packages/devtools-network-console/src/actions/combined.ts
@@ -24,7 +24,8 @@ export function executeRequest(requestId: string, request: INetConsoleRequestInt
         dispatch(startRequestAction(requestId));
         dispatch(beginResponseAction(requestId));
         if (!request.url.startsWith('ws://') && !request.url.startsWith('wss://')) {
-            // dispatch(makeWebSocketDisconnectedAction(requestId));
+            // Clear websocket messages associated with request_id if
+            // request url is changed to no longer point to a websocket.
             dispatch(makeWebSocketClearMessagesAction(requestId));
         }
 

--- a/packages/devtools-network-console/src/actions/combined.ts
+++ b/packages/devtools-network-console/src/actions/combined.ts
@@ -14,6 +14,7 @@ import { beginResponseAction, endResponseAction } from './response/basics';
 import downloadFile from 'utility/download';
 import { IView } from 'store';
 import { INetConsoleRequestInternal } from 'model/NetConsoleRequest';
+import { makeWebSocketClearMessagesAction } from './websocket';
 
 type Thaction = ThunkAction<void, IView, void, any>;
 export function executeRequest(requestId: string, request: INetConsoleRequestInternal, isDownloadForResponse: boolean, environmentalAuthorization: INetConsoleAuthorization | null = null): Thaction {
@@ -22,6 +23,9 @@ export function executeRequest(requestId: string, request: INetConsoleRequestInt
 
         dispatch(startRequestAction(requestId));
         dispatch(beginResponseAction(requestId));
+        if (!request.url.startsWith('ws://') && !request.url.startsWith('wss://')) {
+            dispatch(makeWebSocketClearMessagesAction(requestId));
+        }
 
         try {
             const response = await AppHost.makeRequest(request, environmentalAuthorization, state.environment.environment.variables);

--- a/packages/devtools-network-console/src/actions/websocket/index.ts
+++ b/packages/devtools-network-console/src/actions/websocket/index.ts
@@ -31,11 +31,11 @@ export interface IWebsocketConnectedAction {
     requestId: string;
 }
 
-// TODO: add support for client vs server disconnect
 export interface IWebsocketDisconnectedAction {
     type: 'REQUEST_WEBSOCKET_DISCONNECTED';
 
     requestId: string;
+    reason?: string;
 }
 
 export interface IWebsocketClearMessagesAction {
@@ -70,10 +70,11 @@ export function makeWebSocketConnectedAction(requestId: string): IWebsocketConne
 }
 
 
-export function makeWebSocketDisconnectedAction(requestId: string): IWebsocketDisconnectedAction {
+export function makeWebSocketDisconnectedAction(requestId: string, reason?: string): IWebsocketDisconnectedAction {
     return {
         type: 'REQUEST_WEBSOCKET_DISCONNECTED',
-        requestId
+        requestId,
+        reason
     }
 }
 
@@ -96,7 +97,7 @@ export function sendWsMessage(requestId: string, messageBody: string): ThunkActi
 
 export function sendWsDisconnect(requestId: string): ThunkAction<void, IView, void, AnyAction> {
     return async dispatch => {
-        dispatch(makeWebSocketDisconnectedAction(requestId));
+        dispatch(makeWebSocketDisconnectedAction(requestId, 'Client closed the connection.'));
         AppHost.disconnectWebsocket(requestId);
     };
 }

--- a/packages/devtools-network-console/src/actions/websocket/index.ts
+++ b/packages/devtools-network-console/src/actions/websocket/index.ts
@@ -24,6 +24,13 @@ export interface IWebsocketMessageLoggedAction {
     time: ms;
     content: string;
 }
+
+export interface IWebsocketConnectedAction {
+    type: 'REQUEST_WEBSOCKET_CONNECTED';
+
+    requestId: string;
+}
+
 // TODO: add support for client vs server disconnect
 export interface IWebsocketDisconnectedAction {
     type: 'REQUEST_WEBSOCKET_DISCONNECTED';
@@ -48,6 +55,14 @@ export function makeWebsocketMessageLoggedAction(requestId: string, direction: W
         content,
     };
 }
+
+export function makeWebSocketConnectedAction(requestId: string): IWebsocketConnectedAction {
+    return {
+        type: 'REQUEST_WEBSOCKET_CONNECTED',
+        requestId
+    }
+}
+
 
 export function makeWebSocketDisconnectedAction(requestId: string): IWebsocketDisconnectedAction {
     return {

--- a/packages/devtools-network-console/src/actions/websocket/index.ts
+++ b/packages/devtools-network-console/src/actions/websocket/index.ts
@@ -38,6 +38,12 @@ export interface IWebsocketDisconnectedAction {
     requestId: string;
 }
 
+export interface IWebsocketClearMessagesAction {
+    type: 'REQUEST_WEBSOCKET_CLEAR_MESSAGES';
+
+    requestId: string;
+}
+
 export function makeSendWebsocketMessageAction(requestId: string, messageBody: string): ISendWebsocketMessageAction {
     return {
         type: 'REQUEST_WEBSOCKET_SEND_MESSAGE',
@@ -67,6 +73,13 @@ export function makeWebSocketConnectedAction(requestId: string): IWebsocketConne
 export function makeWebSocketDisconnectedAction(requestId: string): IWebsocketDisconnectedAction {
     return {
         type: 'REQUEST_WEBSOCKET_DISCONNECTED',
+        requestId
+    }
+}
+
+export function makeWebSocketClearMessagesAction(requestId: string): IWebsocketClearMessagesAction {
+    return {
+        type: 'REQUEST_WEBSOCKET_CLEAR_MESSAGES',
         requestId
     }
 }

--- a/packages/devtools-network-console/src/host/host-protocol.md
+++ b/packages/devtools-network-console/src/host/host-protocol.md
@@ -316,6 +316,18 @@ Closes a view.
 }
 ```
 
+### `WEBSOCKET_CONNECTED`
+
+Notifies the frontend that a websocket associated with a particular request has been connected,
+either because of a user request or an error.
+
+```ts
+{
+    type: 'WEBSOCKET_CONNECTED';
+    requestId: string;
+}
+```
+
 ### `WEBSOCKET_DISCONNECTED`
 
 Notifies the frontend that a websocket associated with a particular request has been disconnected,

--- a/packages/devtools-network-console/src/host/host-protocol.md
+++ b/packages/devtools-network-console/src/host/host-protocol.md
@@ -337,7 +337,7 @@ either because of a user request or an error.
 {
     type: 'WEBSOCKET_DISCONNECTED';
     requestId: string;
-    error?: string;
+    reason?: string;
 }
 ```
 

--- a/packages/devtools-network-console/src/host/vscode-protocol-host.ts
+++ b/packages/devtools-network-console/src/host/vscode-protocol-host.ts
@@ -332,17 +332,14 @@ export default class VsCodeProtocolHost implements INetConsoleHost {
     }
 
     protected onWebSocketConnected(message: IWebSocketConnectedMessage) {
-        // TODO: Connect the host message to the global dispatcher
         globalDispatch(makeWebSocketConnectedAction(message.requestId));
     }
 
     protected onWebSocketDisconnected(message: IWebSocketDisconnectedMessage) {
-        // TODO: Connect the host message to the global dispatcher
         globalDispatch(makeWebSocketDisconnectedAction(message.requestId, message.reason));
     }
 
     protected onWebSocketPacket(message: IWebSocketPacketMessage) {
-        // TODO: Establish timing
         globalDispatch(makeWebsocketMessageLoggedAction(message.requestId, message.direction, message.timeFromConnection, message.data));
     }
 

--- a/packages/devtools-network-console/src/host/vscode-protocol-host.ts
+++ b/packages/devtools-network-console/src/host/vscode-protocol-host.ts
@@ -23,6 +23,7 @@ import {
     IUpdateEnvironmentMessage,
     ICloseViewMessage,
     IShowViewMessage,
+    IWebSocketConnectedMessage,
     IWebSocketDisconnectedMessage,
     IWebSocketPacketMessage,
 } from 'network-console-shared/hosting/host-messages';
@@ -46,7 +47,7 @@ import {
     ID_DIV_ROUTE,
 } from 'reducers/request/id-manager';
 import { chooseViewAction, closeViewAction } from 'actions/view-manager';
-import { makeWebsocketMessageLoggedAction, makeWebSocketDisconnectedAction } from 'actions/websocket';
+import { makeWebsocketMessageLoggedAction, makeWebSocketDisconnectedAction, makeWebSocketConnectedAction } from 'actions/websocket';
 
 type PostMessage = (msg: any) => void;
 type HandleMessage = (ev: MessageEvent) => void;
@@ -228,6 +229,10 @@ export default class VsCodeProtocolHost implements INetConsoleHost {
                 this.onShowView(message);
                 break;
 
+            case 'WEBSOCKET_CONNECTED':
+                    this.onWebSocketConnected(message);
+                    break;
+
             case 'WEBSOCKET_DISCONNECTED':
                 this.onWebSocketDisconnected(message);
                 break;
@@ -324,6 +329,11 @@ export default class VsCodeProtocolHost implements INetConsoleHost {
 
     protected onCloseView(message: ICloseViewMessage) {
         globalDispatch(closeViewAction(message.requestId));
+    }
+
+    protected onWebSocketConnected(message: IWebSocketConnectedMessage) {
+        // TODO: Connect the host message to the global dispatcher
+        globalDispatch(makeWebSocketConnectedAction(message.requestId));
     }
 
     protected onWebSocketDisconnected(message: IWebSocketDisconnectedMessage) {

--- a/packages/devtools-network-console/src/host/vscode-protocol-host.ts
+++ b/packages/devtools-network-console/src/host/vscode-protocol-host.ts
@@ -338,7 +338,7 @@ export default class VsCodeProtocolHost implements INetConsoleHost {
 
     protected onWebSocketDisconnected(message: IWebSocketDisconnectedMessage) {
         // TODO: Connect the host message to the global dispatcher
-        globalDispatch(makeWebSocketDisconnectedAction(message.requestId));
+        globalDispatch(makeWebSocketDisconnectedAction(message.requestId, message.reason));
     }
 
     protected onWebSocketPacket(message: IWebSocketPacketMessage) {

--- a/packages/devtools-network-console/src/host/web-application-host.ts
+++ b/packages/devtools-network-console/src/host/web-application-host.ts
@@ -24,7 +24,7 @@ import { DEFAULT_NET_CONSOLE_REQUEST } from 'reducers/request';
 import { synthesizeHttpRequest } from 'utility/http-compose';
 import { recalculateAndApplyTheme } from 'themes/vscode-theme';
 import { INetConsoleRequestInternal } from 'model/NetConsoleRequest';
-import { makeWebsocketMessageLoggedAction, makeWebSocketConnectedAction } from 'actions/websocket';
+import { makeWebsocketMessageLoggedAction, makeWebSocketConnectedAction, makeWebSocketDisconnectedAction } from 'actions/websocket';
 
 export default class WebApplicationHost implements INetConsoleHost {
     constructor() {
@@ -202,6 +202,9 @@ const DEMO_RESPONSES = {
     'Love to. How about Global Thermonuclear War?': `WOULDN'T YOU PREFER A GOOD GAME OF CHESS?`,
     [`Later. Let's play Global Thermonuclear War.`]: 'FINE.',
 };
+
+const DEMO_DISCONNECT_FROM_SERVER = 'server disconnect';
+
 const DEMO_JSON_RESPONSES = {
     [JSON.stringify({ type: 'INIT_CONNECTION', client: 'ws1-info' })]: JSON.stringify({ type: 'PROTOCOL_NEGOTIATION', capabilities: ['authentication', 'synchronization', 'push'] }),
     [JSON.stringify({ type: 'AUTHENTICATE', id: 1, user: 'rob@contoso.com', token: 'adDSAFADSFssda=-1=9331hnhnsdjhjaf.1akjdlfjd' })]: JSON.stringify({ type: 'AUTHENTICATION_ERROR', id: 1, message: 'TOKEN_EXPIRED' }),
@@ -237,6 +240,8 @@ export class WebSocketMock {
             setTimeout(() => {
                 globalDispatch(makeWebsocketMessageLoggedAction(this.requestId, 'recv', Math.floor(Date.now() - this.connected), JSON.stringify({ type: 'ACK', protocol: 'JSON', status: 'OK'})));
             }, 250 + Math.random() * 750);
+        } else if (message === DEMO_DISCONNECT_FROM_SERVER) {
+            globalDispatch(makeWebSocketDisconnectedAction(this.requestId, 'Server closed the connection.'));
         }
     }
 }

--- a/packages/devtools-network-console/src/host/web-application-host.ts
+++ b/packages/devtools-network-console/src/host/web-application-host.ts
@@ -24,7 +24,7 @@ import { DEFAULT_NET_CONSOLE_REQUEST } from 'reducers/request';
 import { synthesizeHttpRequest } from 'utility/http-compose';
 import { recalculateAndApplyTheme } from 'themes/vscode-theme';
 import { INetConsoleRequestInternal } from 'model/NetConsoleRequest';
-import { makeWebsocketMessageLoggedAction } from 'actions/websocket';
+import { makeWebsocketMessageLoggedAction, makeWebSocketConnectedAction } from 'actions/websocket';
 
 export default class WebApplicationHost implements INetConsoleHost {
     constructor() {
@@ -46,6 +46,9 @@ export default class WebApplicationHost implements INetConsoleHost {
         if (request.url === 'wss://www.norad.mil/cheyenne/WOPR') {
             WebSocketMock.instance('wss');
             const time = Math.random() * 1000;
+            setTimeout(() => {
+                globalDispatch(makeWebSocketConnectedAction('DEFAULT_REQUEST'));
+            }, Math.max(time, 0));
             setTimeout(() => {
                 globalDispatch(makeWebsocketMessageLoggedAction('DEFAULT_REQUEST', 'recv', Math.floor(time), 'GREETINGS PROFESSOR FALKEN.'));
             }, time);

--- a/packages/devtools-network-console/src/host/web-application-host.ts
+++ b/packages/devtools-network-console/src/host/web-application-host.ts
@@ -269,7 +269,7 @@ export class WebSocketMock {
     }
 
     disconnect() {
-        globalDispatch(makeWebSocketDisconnectedAction(this.requestId));
+        globalDispatch(makeWebSocketDisconnectedAction(this.requestId, "mock closed connection."));
     }
 }
 
@@ -295,8 +295,8 @@ class ActualWS {
         this._ws.addEventListener('message', e => {
             globalDispatch(makeWebsocketMessageLoggedAction(this.requestId, 'recv', Date.now() - this.connected, e.data));
         });
-        this._ws.addEventListener('close', () => {
-            globalDispatch(makeWebSocketDisconnectedAction(this.requestId));
+        this._ws.addEventListener('close', e => {
+            globalDispatch(makeWebSocketDisconnectedAction(this.requestId, e.reason));
         });
     }
 

--- a/packages/devtools-network-console/src/host/web-application-host.ts
+++ b/packages/devtools-network-console/src/host/web-application-host.ts
@@ -48,7 +48,7 @@ export default class WebApplicationHost implements INetConsoleHost {
             const time = Math.random() * 1000;
             setTimeout(() => {
                 globalDispatch(makeWebSocketConnectedAction('DEFAULT_REQUEST'));
-            }, Math.max(time, 0));
+            }, Math.floor(time/2));
             setTimeout(() => {
                 globalDispatch(makeWebsocketMessageLoggedAction('DEFAULT_REQUEST', 'recv', Math.floor(time), 'GREETINGS PROFESSOR FALKEN.'));
             }, time);

--- a/packages/devtools-network-console/src/model/NetConsoleRequest.ts
+++ b/packages/devtools-network-console/src/model/NetConsoleRequest.ts
@@ -49,5 +49,4 @@ export interface INetConsoleResponseInternal {
     started: ms;
     status: ResponseStatus;
     response: IHttpResponse | null;
-    isWebsocketUpgrade?: boolean;
 }

--- a/packages/devtools-network-console/src/reducers/response/index.ts
+++ b/packages/devtools-network-console/src/reducers/response/index.ts
@@ -45,21 +45,11 @@ export default function reduceResponse(collection: ResponsesState = DEFAULT_RESP
             break;
 
         case 'RESPONSE_END_REQUEST':
-            let isWebsocketUpgrade = false;
-            if (action.response?.statusCode === 101 && action.response?.headers) {
-                for (const header of action.response?.headers) {
-                    if (header.key === "Upgrade" && header.value === "WebSocket"){
-                        isWebsocketUpgrade = true;
-                        break;
-                    }
-                }
-            }
             result = {
                 duration: Date.now() - state.started,
                 started: 0,
                 response: action.response,
                 status: action.status,
-                isWebsocketUpgrade
             };
             break;
 

--- a/packages/devtools-network-console/src/reducers/websocket/index.ts
+++ b/packages/devtools-network-console/src/reducers/websocket/index.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { OrderedSet, Map } from 'immutable';
-import { IWebsocketMessageLoggedAction, WSMsgDirection, IWebsocketDisconnectedAction, IWebsocketConnectedAction } from 'actions/websocket';
+import { IWebsocketMessageLoggedAction, WSMsgDirection, IWebsocketDisconnectedAction, IWebsocketConnectedAction, IWebsocketClearMessagesAction } from 'actions/websocket';
 import { ms } from 'network-console-shared';
 import { IEndRequestAction } from 'actions/response/basics';
 
@@ -24,7 +24,7 @@ const DEFAULT_WS_CONNECTION: IWebSocketConnection = {
     messages: OrderedSet()
 };
 
-export type WebSocketAction = IWebsocketMessageLoggedAction | IWebsocketConnectedAction | IWebsocketDisconnectedAction;
+export type WebSocketAction = IWebsocketMessageLoggedAction | IWebsocketConnectedAction | IWebsocketDisconnectedAction | IWebsocketClearMessagesAction;
 
 export type WS_State = Map<string, IWebSocketConnection>;
 const DEFAULT_WS_STATE: WS_State = Map();
@@ -68,7 +68,7 @@ export default function reduceWebsocket(collection: WS_State = DEFAULT_WS_STATE,
         return collection.set(reqId, state);
     }
     if (action.type === 'REQUEST_WEBSOCKET_DISCONNECTED') {
-        let reqId = action.requestId;
+        const reqId = action.requestId;
         let state = collection.get(reqId);
         if (!state) {
             state = DEFAULT_WS_CONNECTION;
@@ -81,6 +81,19 @@ export default function reduceWebsocket(collection: WS_State = DEFAULT_WS_STATE,
                 direction: 'status',
                 content: 'Disconnected',
             })
+        };
+        return collection.set(reqId, state);
+    }
+    if (action.type === 'REQUEST_WEBSOCKET_CLEAR_MESSAGES') {
+        const reqId = action.requestId;
+        let state = collection.get(reqId);
+        if (!state) {
+            return collection
+        }
+        state = {
+            ...state,
+            connected: false,
+            messages: OrderedSet(),
         };
         return collection.set(reqId, state);
     }

--- a/packages/devtools-network-console/src/reducers/websocket/index.ts
+++ b/packages/devtools-network-console/src/reducers/websocket/index.ts
@@ -83,7 +83,6 @@ export default function reduceWebsocket(collection: WS_State = DEFAULT_WS_STATE,
             }
             state = {
                 ...state,
-                connected: false,
                 messages: OrderedSet(),
             };
             return collection.set(reqId, state);

--- a/packages/devtools-network-console/src/reducers/websocket/index.ts
+++ b/packages/devtools-network-console/src/reducers/websocket/index.ts
@@ -33,70 +33,61 @@ export default function reduceWebsocket(collection: WS_State = DEFAULT_WS_STATE,
     if (!action.requestId) {
         return collection;
     }
-    // TODO: make switch statement
-    if (action.type === 'REQUEST_WEBSOCKET_CONNECTED') {
-        const reqId = action.requestId;
-        let state = collection.get(reqId);
-        if (!state) {
-            state = DEFAULT_WS_CONNECTION;
-        }
-        state = {
-            ...state,
-            connected: true,
-            messages: state.messages.add({
-                direction: 'status',
-                content: 'Connected',
-            })
-        };
-        return collection.set(reqId, state);
+    const reqId = action.requestId;
+    let state = collection.get(reqId);
+    switch (action.type) {
+        case 'REQUEST_WEBSOCKET_CONNECTED':
+            if (!state) {
+                state = DEFAULT_WS_CONNECTION;
+            }
+            state = {
+                ...state,
+                connected: true,
+                messages: state.messages.add({
+                    direction: 'status',
+                    content: 'Connected',
+                })
+            };
+            return collection.set(reqId, state);
+        case 'REQUEST_WEBSOCKET_MESSAGE_LOGGED':
+            if (!state) {
+                state = DEFAULT_WS_CONNECTION;
+            }
+            const { direction, time, content } = action;
+            state = {
+                ...state,
+                messages: state.messages.add({
+                    direction,
+                    time,
+                    content,
+                })
+            };
+            return collection.set(reqId, state);
+        case 'REQUEST_WEBSOCKET_DISCONNECTED':
+            if (!state) {
+                state = DEFAULT_WS_CONNECTION;
+            }
+            const disconnectMessage = action.reason ? `Disconnected: ${action.reason}` : 'Disconnected';
+            state = {
+                ...state,
+                connected: false,
+                messages: state.messages.add({
+                    direction: 'status',
+                    content: disconnectMessage,
+                })
+            };
+            return collection.set(reqId, state);
+        case 'REQUEST_WEBSOCKET_CLEAR_MESSAGES':
+            if (!state) {
+                return collection
+            }
+            state = {
+                ...state,
+                connected: false,
+                messages: OrderedSet(),
+            };
+            return collection.set(reqId, state);
+        default:
+            return collection;
     }
-    if (action.type === 'REQUEST_WEBSOCKET_MESSAGE_LOGGED') {
-        const reqId = action.requestId;
-        let state = collection.get(reqId);
-        if (!state) {
-            state = DEFAULT_WS_CONNECTION;
-        }
-        const { direction, time, content } = action;
-        state = {
-            ...state,
-            messages: state.messages.add({
-                direction,
-                time,
-                content,
-            })
-        };
-        return collection.set(reqId, state);
-    }
-    if (action.type === 'REQUEST_WEBSOCKET_DISCONNECTED') {
-        const reqId = action.requestId;
-        let state = collection.get(reqId);
-        if (!state) {
-            state = DEFAULT_WS_CONNECTION;
-        }
-        // TODO: add disconnected reason/error to content
-        state = {
-            ...state,
-            connected: false,
-            messages: state.messages.add({
-                direction: 'status',
-                content: 'Disconnected',
-            })
-        };
-        return collection.set(reqId, state);
-    }
-    if (action.type === 'REQUEST_WEBSOCKET_CLEAR_MESSAGES') {
-        const reqId = action.requestId;
-        let state = collection.get(reqId);
-        if (!state) {
-            return collection
-        }
-        state = {
-            ...state,
-            connected: false,
-            messages: OrderedSet(),
-        };
-        return collection.set(reqId, state);
-    }
-
-    return collection;
 }

--- a/packages/devtools-network-console/src/reducers/websocket/index.ts
+++ b/packages/devtools-network-console/src/reducers/websocket/index.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { OrderedSet, Map } from 'immutable';
-import { IWebsocketMessageLoggedAction, WSMsgDirection, IWebsocketDisconnectedAction } from 'actions/websocket';
+import { IWebsocketMessageLoggedAction, WSMsgDirection, IWebsocketDisconnectedAction, IWebsocketConnectedAction } from 'actions/websocket';
 import { ms } from 'network-console-shared';
 import { IEndRequestAction } from 'actions/response/basics';
 
@@ -24,7 +24,7 @@ const DEFAULT_WS_CONNECTION: IWebSocketConnection = {
     messages: OrderedSet()
 };
 
-export type WebSocketAction = IWebsocketMessageLoggedAction | IEndRequestAction | IWebsocketDisconnectedAction;
+export type WebSocketAction = IWebsocketMessageLoggedAction | IWebsocketConnectedAction | IWebsocketDisconnectedAction;
 
 export type WS_State = Map<string, IWebSocketConnection>;
 const DEFAULT_WS_STATE: WS_State = Map();
@@ -34,19 +34,7 @@ export default function reduceWebsocket(collection: WS_State = DEFAULT_WS_STATE,
         return collection;
     }
     // TODO: make switch statement
-    if (action.type === 'RESPONSE_END_REQUEST') {
-        let isConnectedWebsocket = false;
-        if (action.response?.statusCode === 101 && action.response?.headers) {
-            for (const header of action.response?.headers) {
-                if (header.key === "Upgrade" && header.value === "WebSocket"){
-                    isConnectedWebsocket = true;
-                    break;
-                }
-            }
-        }
-        if (!isConnectedWebsocket) {
-            return collection;
-        }
+    if (action.type === 'REQUEST_WEBSOCKET_CONNECTED') {
         const reqId = action.requestId;
         let state = collection.get(reqId);
         if (!state) {

--- a/packages/devtools-network-console/src/reducers/websocket/index.ts
+++ b/packages/devtools-network-console/src/reducers/websocket/index.ts
@@ -4,7 +4,6 @@
 import { OrderedSet, Map } from 'immutable';
 import { IWebsocketMessageLoggedAction, WSMsgDirection, IWebsocketDisconnectedAction, IWebsocketConnectedAction, IWebsocketClearMessagesAction } from 'actions/websocket';
 import { ms } from 'network-console-shared';
-import { IEndRequestAction } from 'actions/response/basics';
 
 export interface IWebsocketMessage {
     direction: WSMsgDirection;
@@ -47,6 +46,7 @@ export default function reduceWebsocket(collection: WS_State = DEFAULT_WS_STATE,
                 messages: state.messages.add({
                     direction: 'status',
                     content: 'Connected',
+                    entryNumber: state.messages.count(),
                 })
             };
             return collection.set(reqId, state);
@@ -61,6 +61,7 @@ export default function reduceWebsocket(collection: WS_State = DEFAULT_WS_STATE,
                     direction,
                     time,
                     content,
+                    entryNumber: state.messages.count(),
                 })
             };
             return collection.set(reqId, state);
@@ -75,6 +76,7 @@ export default function reduceWebsocket(collection: WS_State = DEFAULT_WS_STATE,
                 messages: state.messages.add({
                     direction: 'status',
                     content: disconnectMessage,
+                    entryNumber: state.messages.count(),
                 })
             };
             return collection.set(reqId, state);

--- a/packages/devtools-network-console/src/ui/ResponseViewer/index.tsx
+++ b/packages/devtools-network-console/src/ui/ResponseViewer/index.tsx
@@ -262,6 +262,8 @@ function mapStateToProps(state: IView, ownProps: IOwnProps): IConnectedProps {
         throw new Error('Invariant failed: Response not found for given request ID');
     }
     const wsState = state.websocket.get(ownProps.requestId);
+    // Show the Websocket view if there are message associated with this request, even if disconnected.
+    // This allows users to see previous messages and the disconnect status.
     const showWSView = wsState ? wsState.messages.size > 0 : false
     return {
         response: response,

--- a/packages/devtools-network-console/src/ui/ResponseViewer/index.tsx
+++ b/packages/devtools-network-console/src/ui/ResponseViewer/index.tsx
@@ -156,6 +156,7 @@ export function ResponseViewer(props: IResponseViewerProps) {
     }
 
     if (props.showWSView) {
+        // TODO: determine if we can default to the WS tab the first time we connect to a WS
         tabsToDisplay.push(WEBSOCKET_ITEM);
     } else if (currentTab === 'websocket') {
         // TODO: determine if necessary

--- a/packages/devtools-network-console/src/ui/ResponseViewer/index.tsx
+++ b/packages/devtools-network-console/src/ui/ResponseViewer/index.tsx
@@ -24,6 +24,7 @@ import WebSocketView from './WebSocket';
 
 interface IConnectedProps {
     response: INetConsoleResponseInternal;
+    showWSView: boolean;
     theme: THEME_TYPE;
 }
 export interface IOwnProps {
@@ -154,7 +155,7 @@ export function ResponseViewer(props: IResponseViewerProps) {
         setCurrentTab('body');
     }
 
-    if (props.response.isWebsocketUpgrade) {
+    if (props.showWSView) {
         tabsToDisplay.push(WEBSOCKET_ITEM);
     } else if (currentTab === 'websocket') {
         // TODO: determine if necessary
@@ -260,10 +261,12 @@ function mapStateToProps(state: IView, ownProps: IOwnProps): IConnectedProps {
         });
         throw new Error('Invariant failed: Response not found for given request ID');
     }
-
+    const wsState = state.websocket.get(ownProps.requestId);
+    const showWSView = wsState ? wsState.messages.size > 0 : false
     return {
         response: response,
         theme: state.theme.theme,
+        showWSView,
     };
 }
 

--- a/packages/network-console-shared/src/hosting/host-messages.ts
+++ b/packages/network-console-shared/src/hosting/host-messages.ts
@@ -137,6 +137,7 @@ export type HostMessage =
     IUpdateEnvironmentMessage |
     ICloseViewMessage |
     IShowViewMessage |
+    IWebSocketConnectedMessage |
     IWebSocketDisconnectedMessage |
     IWebSocketPacketMessage
     ;

--- a/packages/network-console-shared/src/hosting/host-messages.ts
+++ b/packages/network-console-shared/src/hosting/host-messages.ts
@@ -107,6 +107,10 @@ export interface IShowViewMessage extends IMessage<'SHOW_OPEN_REQUEST'> {
 
 export type IClearEnvironmentMessage = IMessage<'CLEAR_ENVIRONMENT'>;
 
+export interface IWebSocketConnectedMessage extends IMessage<'WEBSOCKET_CONNECTED'> {
+    requestId: string;
+}
+
 export interface IWebSocketDisconnectedMessage extends IMessage<'WEBSOCKET_DISCONNECTED'> {
     requestId: string;
 }

--- a/packages/network-console-shared/src/hosting/host-messages.ts
+++ b/packages/network-console-shared/src/hosting/host-messages.ts
@@ -113,6 +113,7 @@ export interface IWebSocketConnectedMessage extends IMessage<'WEBSOCKET_CONNECTE
 
 export interface IWebSocketDisconnectedMessage extends IMessage<'WEBSOCKET_DISCONNECTED'> {
     requestId: string;
+    reason?: string;
 }
 
 export interface IWebSocketPacketMessage extends IMessage<'WEBSOCKET_PACKET'> {


### PR DESCRIPTION
PR creates a websocket connected host message and wires up an action to respond - this changes the websocket viewer to show up when it receives the ws connected message instead of parsing headers for a websocket upgrade.

Also adds a clear messages action that fires when a request doesn't start with wss or ws (for cases where users change the url in the tab and send a new message