### PR TITLE
Add support for Environment files into the new File-IO feature

### DIFF
--- a/packages/network-console-shared/src/environments/native/native-env-format.ts
+++ b/packages/network-console-shared/src/environments/native/native-env-format.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corp.
 // Licensed under the MIT License.
 
+import deprecated from '../../util/deprecate';
+
 interface INCEnvironmentFolder {
     readonly name: string;
     readonly environments: INCEnvironment[];
@@ -56,6 +58,8 @@ export function serializeNativeEnvironment(
     settings: INetConsoleParameter[],
     addTabs = false,
 ): string {
+    deprecated('serializeNativeEnvironment');
+
     const collection: INCEnvironmentFolder = {
         name: collectionName,
         meta: {

--- a/packages/network-console-shared/src/file_io/convert.ts
+++ b/packages/network-console-shared/src/file_io/convert.ts
@@ -10,6 +10,7 @@ import {
     IEnvironmentContainerAdapter,
     IEnvironmentFormat,
 } from './interfaces';
+import { serializeRequest, serializeAuthorization } from './serialize';
 
 export async function convertFormats(source: ICollectionAdapter, target: ICollectionFormat): Promise<ICollectionAdapter> {
     if (!target.canWrite) {
@@ -46,8 +47,9 @@ async function convertContainer(source: ICollectionAdapter | ICollectionContaine
 }
 
 async function convertRequest(source: ICollectionItemAdapter, targetContainer: ICollectionAdapter | ICollectionContainerAdapter): Promise<void> {
-    const result = await targetContainer.appendItemEntry(source.request);
-    result.request.authorization = source.request.authorization;
+    const request = serializeRequest(source.request);
+    const resultRequest = await targetContainer.appendItemEntry(request);
+    resultRequest.request.authorization = request.authorization;
 }
 
 export function migrateAuthorization(target: INetConsoleAuthorization, source: INetConsoleAuthorization) {

--- a/packages/network-console-shared/src/file_io/convert.ts
+++ b/packages/network-console-shared/src/file_io/convert.ts
@@ -72,7 +72,6 @@ export async function convertEnvironment(source: IEnvironmentContainerAdapter, t
     }
 
     const targetEnvironmentContainer = await target.createEnvironmentContainer(source.name);
-    debugger;
     const copyingMultipleEnvironments = (environmentIds.length > 1) ||
         (environmentIds.length === 0 && source.childIds.length > 1);
     if (copyingMultipleEnvironments && !targetEnvironmentContainer.canContainMultipleEnvironments) {

--- a/packages/network-console-shared/src/file_io/index.ts
+++ b/packages/network-console-shared/src/file_io/index.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { ICollectionFormat } from './interfaces';
+import { ICollectionFormat, IEnvironmentFormat } from './interfaces';
+
 import { CollectionFormat as NativeCollectionFormat } from './native/collection-format';
 import { CollectionFormat as PostmanV2Point1CollectionFormat } from './postman/v2.1/collection-format';
 import { CollectionFormat as OpenAPICollectionFormat } from './openapi/collection-format';
@@ -18,7 +19,7 @@ const formats = {
 export default formats;
 
 export const environmentFormats = {
-    'nc-native-env': new NativeEnvironmentFormat(),
-    'postman-v2.1-env': new PostmanEnvironmentFormat(),
-    'openapi-env': new OpenAPIEnvironmentFormat(),
+    'nc-native-env': (new NativeEnvironmentFormat()) as IEnvironmentFormat,
+    'postman-v2.1-env': (new PostmanEnvironmentFormat()) as IEnvironmentFormat,
+    'openapi-env': (new OpenAPIEnvironmentFormat()) as IEnvironmentFormat,
 };

--- a/packages/network-console-shared/src/file_io/index.ts
+++ b/packages/network-console-shared/src/file_io/index.ts
@@ -6,9 +6,19 @@ import { CollectionFormat as NativeCollectionFormat } from './native/collection-
 import { CollectionFormat as PostmanV2Point1CollectionFormat } from './postman/v2.1/collection-format';
 import { CollectionFormat as OpenAPICollectionFormat } from './openapi/collection-format';
 
+import { EnvironmentFormat as NativeEnvironmentFormat } from './native/environment-format';
+import { EnvironmentFormat as PostmanEnvironmentFormat } from './postman/v2.1/environment-format';
+import { EnvironmentFormat as OpenAPIEnvironmentFormat } from './openapi/environment-format';
+
 const formats = {
     'nc-native': new NativeCollectionFormat() as ICollectionFormat,
     'postman-v2.1': new PostmanV2Point1CollectionFormat() as ICollectionFormat,
     'openapi': new OpenAPICollectionFormat() as ICollectionFormat,
 };
 export default formats;
+
+export const environmentFormats = {
+    'nc-native-env': new NativeEnvironmentFormat(),
+    'postman-v2.1-env': new PostmanEnvironmentFormat(),
+    'openapi-env': new OpenAPIEnvironmentFormat(),
+};

--- a/packages/network-console-shared/src/file_io/interfaces.ts
+++ b/packages/network-console-shared/src/file_io/interfaces.ts
@@ -1,7 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { INetConsoleAuthorization, INetConsoleRequest } from '../net/net-console-http';
+import {
+    INetConsoleAuthorization,
+    INetConsoleRequest,
+    INetConsoleParameter,
+} from '../net/net-console-http';
 
 /**
  * This interface describes a supported format for interacting with a Collection.
@@ -111,4 +115,63 @@ export interface ICollectionItemAdapter extends ICollectionEntryAdapter {
     type: 'item';
 
     readonly request: INetConsoleRequest;
+}
+
+export interface IEnvironmentFormat {
+    /**
+     * Gets an internal ID for the format.
+     */
+    readonly formatId: string;
+    /**
+     * Gets whether this format, or any of the objects it produces, are writable.
+     * If not, attempting to write to any of them will raise an exception.
+     */
+    readonly canWrite: boolean;
+
+    /**
+     * Creates a new, empty environment container in this format. If `canWrite` is false,
+     * this method may throw an error.
+     *
+     * @param name Environment container name
+     */
+    createEnvironmentContainer(name: string): Promise<IEnvironmentContainerAdapter>;
+    /**
+     * Parses text contents of a file. If errors are detected, this function may
+     * raise an error; however, that is not guaranteed for all contents.
+     *
+     * @param id A unique ID of this collection.
+     * @param contents The file contents.
+     */
+    parse(id: string, contents: string): Promise<IEnvironmentContainerAdapter>;
+    /**
+     * Tries to parse text contents of a file. If it fails, will return `null`.
+     *
+     * @param id A unique ID of this collection.
+     * @param contents The file contents.
+     */
+    tryParse(id: string, contents: string): Promise<IEnvironmentContainerAdapter | null>;
+}
+
+export interface IEnvironmentContainerAdapter {
+    readonly format: IEnvironmentFormat;
+    readonly id: string;
+    readonly isDirty: boolean;
+    readonly canContainMultipleEnvironments: boolean;
+
+    name: string;
+
+    readonly childIds: string[];
+    getEnvironmentById(id: string): IEnvironmentAdapter | null;
+
+    appendEnvironment(name: string): Promise<IEnvironmentAdapter>;
+    deleteEnvironment(id: string): Promise<void>;
+
+    stringify(): Promise<string>;
+    commit(): Promise<void>;
+}
+
+export interface IEnvironmentAdapter {
+    name: string;
+
+    variables: INetConsoleParameter[];
 }

--- a/packages/network-console-shared/src/file_io/native/environment-adapter.ts
+++ b/packages/network-console-shared/src/file_io/native/environment-adapter.ts
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+    IEnvironmentFormat,
+    IEnvironmentContainerAdapter,
+    IEnvironmentAdapter,
+} from '../interfaces';
+import { INCNativeEnvironment } from './environment-format';
+import { INetConsoleParameter } from '../../net/net-console-http';
+
+export class EnvironmentAdapter implements IEnvironmentAdapter {
+    constructor(
+        public readonly format: IEnvironmentFormat,
+        public readonly container: IEnvironmentContainerAdapter,
+        public readonly id: string,
+        private readonly realObject: INCNativeEnvironment,
+        private setDirty: () => void,
+    ) {
+
+    }
+
+    get name() {
+        return this.realObject.name;
+    }
+
+    set name(value: string) {
+        this.realObject.name = value;
+        this.setDirty();
+    }
+
+    get variables() {
+        return this.realObject.variables.map(p => {
+            const { description, isActive, key, value } = p;
+            return { description, isActive, key, value };
+        });
+    }
+
+    set variables(value: INetConsoleParameter[]) {
+        this.realObject.variables = value.map(p => {
+            const { description, isActive, key, value } = p;
+            return { description, isActive, key, value };
+        });
+        this.setDirty();
+    }
+}

--- a/packages/network-console-shared/src/file_io/native/environment-container-adapter.ts
+++ b/packages/network-console-shared/src/file_io/native/environment-container-adapter.ts
@@ -1,0 +1,167 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+    IEnvironmentAdapter,
+    IEnvironmentContainerAdapter,
+    IEnvironmentFormat,
+} from '../interfaces';
+import {
+    INCNativeEnvironment,
+    INCNativeEnvironmentFile,
+} from './environment-format';
+import { EnvironmentAdapter } from './environment-adapter';
+import BidiMap from '../../util/bidi-map';
+
+type ValidityCheckResult = {
+    valid: true;
+    parsed: INCNativeEnvironmentFile;
+} | {
+    valid: false;
+    error: string;
+};
+
+export class EnvironmentContainerAdapter implements IEnvironmentContainerAdapter {
+    public canContainMultipleEnvironments = true;
+    private _dirty: boolean;
+    private _current: INCNativeEnvironmentFile;
+    private _keyToIndex: BidiMap<string, number>;
+    private _nextKey: number;
+
+    constructor(
+        public readonly format: IEnvironmentFormat,
+        public readonly id: string,
+        private fileContents: string,
+    ) {
+        const root = EnvironmentContainerAdapter.isValidFile(fileContents);
+        if (!root.valid) {
+            throw new RangeError('Invalid file or error parsing: ' + root.error);
+        }
+
+        this._current = root.parsed;
+        this._dirty = false;
+        this._keyToIndex = new BidiMap();
+        this._nextKey = 0;
+
+        for (let index = 0; index < this._current.environments.length; index++) {
+            const entryId = `${id}/${this._nextKey++}`;
+            this._keyToIndex.set(entryId, index);
+        }
+    }
+
+    static isValidFile(fileContents: string): ValidityCheckResult {
+        try {
+            const parsed = JSON.parse(fileContents) as Partial<INCNativeEnvironmentFile>;
+            if (!('meta' in parsed)) {
+                return {
+                    valid: false,
+                    error: 'No metadata about the file.',
+                };
+            }
+            if (!('networkConsoleEnvironmentVersion' in parsed.meta!)) {
+                return {
+                    valid: false,
+                    error: 'No version key for this file.',
+                };
+            }
+            if(!('name' in parsed)) {
+                return {
+                    valid: false,
+                    error: 'No name for this file.',
+                };
+            }
+            if (!('environments' in parsed) || !Array.isArray(parsed.environments)) {
+                return {
+                    valid: false,
+                    error: 'Expected "environments" list was missing or not an array.',
+                };
+            }
+
+            return {
+                valid: true,
+                parsed: parsed as INCNativeEnvironmentFile,
+            };
+        }
+        catch (e) {
+            return {
+                valid: false,
+                error: 'Invalid JSON: ' + e.message,
+            };
+        }
+    }
+
+    get isDirty() {
+        return this._dirty;
+    }
+
+    get name() {
+        return this._current.name;
+    }
+
+    set name(value: string) {
+        this._current.name = value;
+        this._dirty = true;
+    }
+
+    get childIds() {
+        return Array.from(this._keyToIndex.keys());
+    }
+
+    getEnvironmentById(id: string): IEnvironmentAdapter | null {
+        const index = this._keyToIndex.getByKey(id);
+        if (typeof index !== 'number') {
+            return null;
+        }
+
+        const environment = this._current.environments[index] as INCNativeEnvironment;
+        if (!environment) {
+            throw new Error(`Parser error: Child with id "${id}" was not found.`);
+        }
+
+        return new EnvironmentAdapter(this.format, this, id, environment, () => { this._dirty = true; });
+    }
+
+    async appendEnvironment(name: string): Promise<IEnvironmentAdapter> {
+        const child: INCNativeEnvironment = {
+            name,
+            variables: [],
+        };
+        const index = this._current.environments.length;
+        this._current.environments.push(child);
+        const id = `${this.id}/${this._nextKey++}`;
+        this._keyToIndex.set(id, index);
+        this._dirty = true;
+
+        return new EnvironmentAdapter(this.format, this, id, child, () => { this._dirty = true; });
+    }
+
+    async deleteEnvironment(id: string): Promise<void> {
+        const index = this._keyToIndex.getByKey(id);
+        if (typeof index !== 'number') {
+            throw new RangeError(`ID "${id}" not found in this container.`);
+        }
+
+        this._keyToIndex.deleteByKey(id);
+        this._current.environments.splice(index, 1);
+        this._dirty = true;
+
+        // Move all values up by one
+        const valuesList = Array.from(this._keyToIndex.values()).filter(v => v > index);
+        valuesList.sort();
+        // This will never error because it's traversed from least to greatest.
+        for (const oldIndex of valuesList) {
+            const key = this._keyToIndex.getByValue(oldIndex)!;
+            this._keyToIndex.deleteByKey(key);
+            this._keyToIndex.set(key, oldIndex - 1);
+        }
+    }
+
+    async stringify(): Promise<string> {
+        return this.fileContents;
+    }
+
+    async commit(): Promise<void> {
+        this.fileContents = JSON.stringify(this._current, null, 4);
+        this._dirty = false;
+    }
+}

--- a/packages/network-console-shared/src/file_io/native/environment-format.ts
+++ b/packages/network-console-shared/src/file_io/native/environment-format.ts
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+    IEnvironmentFormat,
+    IEnvironmentContainerAdapter,
+} from '../interfaces';
+import { EnvironmentContainerAdapter } from './environment-container-adapter';
+import { INetConsoleParameter } from '../../net/net-console-http';
+
+export interface INCNativeEnvironmentFile {
+    meta: {
+        networkConsoleEnvironmentVersion: string;
+    };
+    name: string;
+    environments: INCNativeEnvironment[];
+}
+
+export interface INCNativeEnvironment {
+    name: string;
+    variables: INetConsoleParameter[];
+}
+
+export class EnvironmentFormat implements IEnvironmentFormat {
+    public readonly formatId = 'nc-native-env';
+    public readonly canWrite = true;
+
+    private static _nextNewEnvironmentId = 0;
+
+    constructor() {}
+
+    async createEnvironmentContainer(name: string): Promise<IEnvironmentContainerAdapter> {
+        const DEFAULT_ENVIRONMENT: INCNativeEnvironmentFile = {
+            meta: {
+                networkConsoleEnvironmentVersion: '0.9.2-preview',
+            },
+            name,
+            environments: [],
+        };
+
+        const id = `nc-native-format-new-environment-${EnvironmentFormat._nextNewEnvironmentId++}`;
+        return new EnvironmentContainerAdapter(this, id, JSON.stringify(DEFAULT_ENVIRONMENT, null, 4));
+    }
+
+    async parse(id: string, contents: string): Promise<IEnvironmentContainerAdapter> {
+        return new EnvironmentContainerAdapter(this, id, contents);
+    }
+
+    async tryParse(id: string, contents: string): Promise<IEnvironmentContainerAdapter | null> {
+        try {
+            return await this.parse(id, contents);
+        }
+        catch (_err) {
+            return null;
+        }
+    }
+}

--- a/packages/network-console-shared/src/file_io/native/test/environment-container-adapter.test.ts
+++ b/packages/network-console-shared/src/file_io/native/test/environment-container-adapter.test.ts
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// tslint:disable:no-unused-expression
+
+import chai, { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import 'mocha';
+import jsonCompare from '../../../test-util/json-compare';
+
+chai.use(chaiAsPromised);
+
+import { IEnvironmentContainerAdapter } from '../../interfaces';
+import { EnvironmentFormat } from '../environment-format';
+
+describe('network-console-shared/src/file_io/native/environment-container-adapter', () => {
+    describe('Manipulation of an empty Environment container', () => {
+        let container: IEnvironmentContainerAdapter;
+
+        beforeEach(async () => {
+            (EnvironmentFormat as any)._nextNewEnvironmentId = 0;
+            const format = new EnvironmentFormat();
+            container = await format.createEnvironmentContainer('Test container');
+        });
+
+        it('renames the environment container correctly', async () => {
+            const expected = JSON.stringify({
+                meta: {
+                    networkConsoleEnvironmentVersion: '0.9.2-preview',
+                },
+                name: 'Renamed environment container',
+                environments: [],
+            });
+            expect(container.isDirty).to.be.false;
+            container.name = 'Renamed environment container';
+            expect(container.isDirty).to.be.true;
+            await container.commit();
+            expect(container.isDirty).to.be.false;
+            jsonCompare(await container.stringify(), expected);
+        });
+
+        it('adds a new environment to the container correctly', async () => {
+            const expected = JSON.stringify({
+                meta: {
+                    networkConsoleEnvironmentVersion: '0.9.2-preview',
+                },
+                name: 'Test container',
+                environments: [{
+                    name: 'Test environment',
+                    variables: []
+                }],
+            });
+            await container.appendEnvironment('Test environment');
+            expect(container.isDirty).to.be.true;
+            await container.commit();
+            jsonCompare(await container.stringify(), expected);
+        });
+
+        it('adds a new environment and variables to the container correctly', async () => {
+            const expected = JSON.stringify({
+                meta: {
+                    networkConsoleEnvironmentVersion: '0.9.2-preview',
+                },
+                name: 'Test container',
+                environments: [{
+                    name: 'Test environment',
+                    variables: [{
+                        description: 'The base part of URI requests',
+                        isActive: true,
+                        key: 'uriroot',
+                        value: 'http://localhost:3000/'
+                    }],
+                }],
+            });
+            const env = await container.appendEnvironment('Test environment');
+            await container.commit();
+            env.variables = [{
+                description: 'The base part of URI requests',
+                isActive: true,
+                key: 'uriroot',
+                value: 'http://localhost:3000/',
+            }];
+            expect(container.isDirty).to.be.true;
+            await container.commit();
+            jsonCompare(await container.stringify(), expected);
+        });
+    });
+});

--- a/packages/network-console-shared/src/file_io/native/test/environment-format.test.ts
+++ b/packages/network-console-shared/src/file_io/native/test/environment-format.test.ts
@@ -1,0 +1,146 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import chai, { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import 'mocha';
+chai.use(chaiAsPromised);
+
+import { EnvironmentFormat, INCNativeEnvironmentFile } from '../environment-format';
+
+describe('network-console-shared/src/file_io/native/environment-format', () => {
+    it('creates a default environment and serializes it correctly', async () => {
+        const format = new EnvironmentFormat();
+        const name = 'Empty test environment';
+        const expected: INCNativeEnvironmentFile = {
+            meta: {
+                networkConsoleEnvironmentVersion: '0.9.2-preview',
+            },
+            name,
+            environments: [],
+        };
+
+        const collection = await format.createEnvironmentContainer(name);
+        expect(await collection.stringify()).to.deep.equal(JSON.stringify(expected, null, 4));
+    });
+
+    describe('Variations of EnvironmentFormat#parse failures', () => {
+        it('Throws if the root lacks a meta field', () => {
+            async function test() {
+                const format = new EnvironmentFormat();
+                const expected = JSON.stringify({
+                    name: 'Known bad',
+                    environments: [],
+                }, null, 4);
+                await format.parse('Known bad', expected);
+            }
+
+            return expect(test()).to.eventually.be.rejectedWith(RangeError);
+        });
+
+        it('Throws if the root metadata lacks a version field', () => {
+            async function test() {
+                const format = new EnvironmentFormat();
+                const expected = JSON.stringify({
+                    meta: {},
+                    name: 'Known bad',
+                    environments: [],
+                }, null, 4);
+                await format.parse('Known bad', expected);
+            }
+
+            return expect(test()).to.eventually.be.rejectedWith(RangeError);
+        });
+
+        it('Throws if the root lacks a name field', () => {
+            async function test() {
+                const format = new EnvironmentFormat();
+                const expected = JSON.stringify({
+                    meta: {
+                        version: '0.9.2-preview',
+                    },
+                    environments: [],
+                }, null, 4);
+                await format.parse('Known bad', expected);
+            }
+
+            return expect(test()).to.eventually.be.rejectedWith(RangeError);
+        });
+
+        it('Throws if the root lacks a meta field', () => {
+            async function test() {
+                const format = new EnvironmentFormat();
+                const expected = JSON.stringify({
+                    meta: {
+                        version: '0.9.2-preview',
+                    },
+                    name: 'Known bad',
+                    environments: 'This should have been an array.',
+                }, null, 4);
+                await format.parse('Known bad', expected);
+            }
+
+            return expect(test()).to.eventually.be.rejectedWith(RangeError);
+        });
+    });
+
+    describe('Variations of EnvironmentFormat#tryParse failures', () => {
+        it('Throws if the root lacks a meta field', () => {
+            async function test() {
+                const format = new EnvironmentFormat();
+                const expected = JSON.stringify({
+                    name: 'Known bad',
+                    environments: [],
+                }, null, 4);
+                return await format.tryParse('Known bad', expected);
+            }
+
+            return expect(test()).to.eventually.be.null;
+        });
+
+        it('Throws if the root metadata lacks a version field', () => {
+            async function test() {
+                const format = new EnvironmentFormat();
+                const expected = JSON.stringify({
+                    meta: {},
+                    name: 'Known bad',
+                    environments: [],
+                }, null, 4);
+                return await format.tryParse('Known bad', expected);
+            }
+
+            return expect(test()).to.eventually.be.null;
+        });
+
+        it('Throws if the root lacks a name field', () => {
+            async function test() {
+                const format = new EnvironmentFormat();
+                const expected = JSON.stringify({
+                    meta: {
+                        version: '0.9.2-preview',
+                    },
+                    environments: [],
+                }, null, 4);
+                return await format.tryParse('Known bad', expected);
+            }
+
+            return expect(test()).to.eventually.be.null;
+        });
+
+        it('Throws if the root lacks a meta field', () => {
+            async function test() {
+                const format = new EnvironmentFormat();
+                const expected = JSON.stringify({
+                    meta: {
+                        version: '0.9.2-preview',
+                    },
+                    name: 'Known bad',
+                    environments: 'This should have been an array.',
+                }, null, 4);
+                return await format.tryParse('Known bad', expected);
+            }
+
+            return expect(test()).to.eventually.be.null;
+        });
+    });
+});

--- a/packages/network-console-shared/src/file_io/openapi/environment-format.ts
+++ b/packages/network-console-shared/src/file_io/openapi/environment-format.ts
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import SwaggerParser from 'swagger-parser';
+import { OpenAPIV2 } from 'openapi-types';
+import {
+    IEnvironmentFormat,
+    IEnvironmentContainerAdapter,
+} from '../interfaces';
+import { EnvironmentContainerAdapter as EnvironmentContainerAdapterV2 } from './v2/environment-container-adapter';
+
+export class EnvironmentFormat implements IEnvironmentFormat {
+    public readonly formatId = 'openapi-v2-env';
+    public readonly canWrite = false;
+
+    constructor() {}
+
+    async createEnvironmentContainer(name: string): Promise<IEnvironmentContainerAdapter> {
+        throw new ReferenceError('Writing is not supported for this format.');
+    }
+
+    async parse(id: string, fileContents: string): Promise<IEnvironmentContainerAdapter> {
+        try {
+            let loadState = false;
+            const contents = await (SwaggerParser as any as typeof SwaggerParser.default).validate(id, {
+                resolve: {
+                    external: false,
+                    file: {
+                        canRead: () => {
+                            if (loadState === false) {
+                                loadState = true;
+                                return true;
+                            }
+                            return false;
+                        },
+                        read: () => {
+                            return fileContents;
+                        }
+                    },
+                    http: {
+                        canRead: () => {
+                            if (loadState === false) {
+                                loadState = true;
+                                return true;
+                            }
+                            return false;
+                        },
+                        read: () => {
+                            return fileContents;
+                        },
+                    },
+                },
+            });
+            if ((contents as any).swagger?.startsWith?.('2.0')) {
+                return new EnvironmentContainerAdapterV2(this, id, contents as OpenAPIV2.Document);
+            }
+
+            throw new ReferenceError(`Version "${(contents as any).swagger}" not supported.`);
+        }
+        catch (err) {
+            throw new RangeError(err.message);
+        }
+    }
+
+    async tryParse(id: string, contents: string): Promise<IEnvironmentContainerAdapter | null> {
+        try {
+            return await this.parse(id, contents);
+        }
+        catch (_err) {
+            return null;
+        }
+    }
+}

--- a/packages/network-console-shared/src/file_io/openapi/v2/environment-container-adapter.ts
+++ b/packages/network-console-shared/src/file_io/openapi/v2/environment-container-adapter.ts
@@ -1,0 +1,124 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { OpenAPIV2 } from 'openapi-types';
+
+import {
+    IEnvironmentAdapter,
+    IEnvironmentContainerAdapter,
+    IEnvironmentFormat,
+} from '../../interfaces';
+import { INetConsoleParameter } from '../../../net/net-console-http';
+import BidiMap from '../../../util/bidi-map';
+
+export class EnvironmentContainerAdapter implements IEnvironmentContainerAdapter {
+    public readonly canContainMultipleEnvironments = true;
+    public readonly isDirty = false;
+    private readonly children: IEnvironmentAdapter[] = [];
+    private _keyToIndex: BidiMap<string, number> = new BidiMap();
+
+    constructor(
+        public readonly format: IEnvironmentFormat,
+        public readonly id: string,
+        private readonly document: OpenAPIV2.Document,
+    ) {
+        const host = document.host;
+        if (!host) {
+            throw new RangeError('This OpenAPI document may not be used as an environment because it does not include a "host" property.');
+        }
+        const basePath = document.basePath || '/';
+        if (document.schemes) {
+            for (const scheme of document.schemes) {
+                const environmentId = `${id}/${scheme}`;
+                const env = new EnvironmentAdapter(environmentId, scheme, scheme, host, basePath);
+                const index = this.children.length;
+                this._keyToIndex.set(environmentId, index);
+                this.children.push(env);
+            }
+        }
+        else {
+            const scheme = 'https';
+            const environmentId = `${id}/${scheme}`;
+            const env = new EnvironmentAdapter(environmentId, scheme, scheme, host, basePath);
+            const index = this.children.length;
+            this._keyToIndex.set(environmentId, index);
+            this.children.push(env);
+        }
+    }
+
+    get name() {
+        return `${this.document.info.title} (OpenAPI)`;
+    }
+
+    set name(_value: string) {
+        failReadonly();
+    }
+
+    get childIds() {
+        return Array.from(this._keyToIndex.keys());
+    }
+
+    getEnvironmentById(id: string): IEnvironmentAdapter | null {
+        const env = this._keyToIndex.getByKey(id);
+        if (typeof env !== 'number') {
+            return null;
+        }
+
+        const entry = this.children[env];
+        return entry;
+    }
+
+    async appendEnvironment(_name: string): Promise<IEnvironmentAdapter> {
+        failReadonly();
+    }
+
+    async deleteEnvironment(_id: string): Promise<void> {
+        failReadonly();
+    }
+
+    async stringify(): Promise<string> {
+        return JSON.stringify(this.document, null, 4);
+    }
+
+    async commit() {
+        failReadonly();
+    }
+}
+
+class EnvironmentAdapter implements IEnvironmentAdapter {
+    private _entry: INetConsoleParameter;
+    constructor(
+        public readonly id: string,
+        private readonly environmentName: string,
+        private readonly scheme: string,
+        private readonly host: string,
+        private readonly basePath: string,
+    ) {
+        this._entry = {
+            description: 'Auto-generated from the OpenAPI document to access the root of the API service',
+            isActive: true,
+            key: 'baseUri',
+            value: `${scheme || 'https'}://${host}${basePath}`,
+        };
+    }
+
+    get name() {
+        return this.scheme;
+    }
+
+    set name(_value: string) {
+        failReadonly();
+    }
+
+    get variables() {
+        return [this._entry];
+    }
+
+    set variables(_value: INetConsoleParameter[]) {
+        failReadonly();
+    }
+}
+
+function failReadonly(): never {
+    throw new ReferenceError('Writing to this environment is not supported.');
+}

--- a/packages/network-console-shared/src/file_io/openapi/v2/test/environment-container-adapter.test.ts
+++ b/packages/network-console-shared/src/file_io/openapi/v2/test/environment-container-adapter.test.ts
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// tslint:disable:no-unused-expression
+
+import chai, { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import 'mocha';
+import { getContents } from '../../../../test-util/read-collection';
+
+chai.use(chaiAsPromised);
+
+import { EnvironmentFormat } from '../../environment-format';
+
+async function loadValidEnvironment() {
+    const fileContents = await getContents('src/file_io/openapi/v2/test/cases/petstore-swagger-io.json');
+    const format = new EnvironmentFormat();
+
+    return await format.parse('petstore-swagger-io.json', fileContents);
+}
+
+describe('network-console-shared/src/file_io/openapi/v2/environment-container-adapter', () => {
+    describe('Manipulation of an environment container', () => {
+        it('Throws if you try to create an environment', async () => {
+            function test() {
+                const format = new EnvironmentFormat();
+                return format.createEnvironmentContainer('Will not work');
+            }
+
+            await expect(test()).to.eventually.be.rejectedWith(ReferenceError);
+        });
+
+        it('Throws if you try to rename an environment', async () => {
+            async function test() {
+                const environment = await loadValidEnvironment();
+                environment.name = 'Hello world.';
+            }
+
+            await expect(test()).to.eventually.be.rejectedWith(ReferenceError);
+        });
+
+        it('Throws if you try to add an environment to the root', async () => {
+            async function test() {
+                const env = await loadValidEnvironment();
+                await env.appendEnvironment('This will fail.');
+            }
+
+            await expect(test()).to.eventually.be.rejectedWith(ReferenceError);
+        });
+
+        it('Throws if you try to delete an environment', async () => {
+            async function test() {
+                const env = await loadValidEnvironment();
+                const firstChild = env.childIds[0];
+                await env.deleteEnvironment(firstChild);
+            }
+
+            await expect(test()).to.eventually.be.rejectedWith(ReferenceError);
+        });
+
+        it('Throws if trying to commit', async () => {
+            async function test() {
+                const env = await loadValidEnvironment();
+                await env.commit();
+            }
+
+            await expect(test()).to.eventually.be.rejectedWith(ReferenceError);
+        });
+    });
+
+    describe('Loads an environment appropriately', () => {
+        it('Loads a valid environment with two configurations', async () => {
+            const env = await loadValidEnvironment();
+            const expectedIds = [`${env.id}/https`, `${env.id}/http`];
+            expect(env.childIds).to.deep.equal(expectedIds);
+
+            const expectedHttpsVariables = [
+                {
+                    description: 'Auto-generated from the OpenAPI document to access the root of the API service',
+                    isActive: true,
+                    key: 'baseUri',
+                    value: 'https://petstore.swagger.io/v2',
+                },
+            ];
+            const httpsEnv = env.getEnvironmentById(`${env.id}/https`);
+            expect(httpsEnv!.name).to.equal('https');
+            expect(httpsEnv!.variables).to.deep.equal(expectedHttpsVariables);
+
+            const expectedHttpVariables = [
+                {
+                    description: 'Auto-generated from the OpenAPI document to access the root of the API service',
+                    isActive: true,
+                    key: 'baseUri',
+                    value: 'http://petstore.swagger.io/v2',
+                },
+            ];
+            const httpEnv = env.getEnvironmentById(`${env.id}/http`);
+            expect(httpEnv!.name).to.equal('http');
+            expect(httpEnv!.variables).to.deep.equal(expectedHttpVariables);
+        });
+    });
+});

--- a/packages/network-console-shared/src/file_io/postman/v2.1/environment-container-adapter.ts
+++ b/packages/network-console-shared/src/file_io/postman/v2.1/environment-container-adapter.ts
@@ -11,7 +11,7 @@ import {
 } from './environment-format';
 import { INetConsoleParameter } from '../../../net/net-console-http';
 
-type ValidityCheckResult = {
+type ParseResult = {
     valid: true;
     parsed: IPostmanEnvironmentFile;
 } | {
@@ -30,7 +30,7 @@ export class EnvironmentContainerAdapter implements IEnvironmentContainerAdapter
         public readonly id: string,
         private fileContents: string,
     ) {
-        const root = EnvironmentContainerAdapter.isValidFile(fileContents);
+        const root = EnvironmentContainerAdapter.checkAndParse(fileContents);
         if (!root.valid) {
             throw new RangeError('Invalid file or error parsing: ' + root.error);
         }
@@ -40,7 +40,7 @@ export class EnvironmentContainerAdapter implements IEnvironmentContainerAdapter
         this._childKey = `${id}/0`;
     }
 
-    static isValidFile(fileContents: string): ValidityCheckResult {
+    static checkAndParse(fileContents: string): ParseResult {
         try {
             const parsed = JSON.parse(fileContents) as Partial<IPostmanEnvironmentFile>;
             if (!('id' in parsed)) {

--- a/packages/network-console-shared/src/file_io/postman/v2.1/environment-container-adapter.ts
+++ b/packages/network-console-shared/src/file_io/postman/v2.1/environment-container-adapter.ts
@@ -1,0 +1,143 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+    IEnvironmentAdapter,
+    IEnvironmentContainerAdapter,
+    IEnvironmentFormat,
+} from '../../interfaces';
+import {
+    IPostmanEnvironmentFile
+} from './environment-format';
+import { INetConsoleParameter } from '../../../net/net-console-http';
+
+type ValidityCheckResult = {
+    valid: true;
+    parsed: IPostmanEnvironmentFile;
+} | {
+    valid: false;
+    error: string;
+};
+
+export class EnvironmentContainerAdapter implements IEnvironmentContainerAdapter, IEnvironmentAdapter {
+    public readonly canContainMultipleEnvironments = false;
+    private _dirty: boolean;
+    private _current: IPostmanEnvironmentFile;
+    private _childKey: string;
+
+    constructor(
+        public readonly format: IEnvironmentFormat,
+        public readonly id: string,
+        private fileContents: string,
+    ) {
+        const root = EnvironmentContainerAdapter.isValidFile(fileContents);
+        if (!root.valid) {
+            throw new RangeError('Invalid file or error parsing: ' + root.error);
+        }
+
+        this._current = root.parsed;
+        this._dirty = false;
+        this._childKey = `${id}/0`;
+    }
+
+    static isValidFile(fileContents: string): ValidityCheckResult {
+        try {
+            const parsed = JSON.parse(fileContents) as Partial<IPostmanEnvironmentFile>;
+            if (!('id' in parsed)) {
+                return {
+                    valid: false,
+                    error: 'No ID in the file.',
+                };
+            }
+            if(!('name' in parsed)) {
+                return {
+                    valid: false,
+                    error: 'No name for this file.',
+                };
+            }
+            if (!('values' in parsed) || !Array.isArray(parsed.values)) {
+                return {
+                    valid: false,
+                    error: 'Expected "values" list was missing or not an array.',
+                };
+            }
+
+            return {
+                valid: true,
+                parsed: parsed as IPostmanEnvironmentFile,
+            };
+        }
+        catch (e) {
+            return {
+                valid: false,
+                error: 'Invalid JSON: ' + e.message,
+            };
+        }
+    }
+
+    get isDirty() {
+        return this._dirty;
+    }
+
+    get childIds() {
+        return [this._childKey];
+    }
+
+    getEnvironmentById(id: string): IEnvironmentAdapter | null {
+        if (id !== this._childKey) {
+            return null;
+        }
+
+        return this;
+    }
+
+    async appendEnvironment(name: string): Promise<IEnvironmentAdapter> {
+        throw new ReferenceError('Multiple environments are not supported for this container.');
+    }
+
+    async deleteEnvironment(id: string): Promise<void> {
+        throw new ReferenceError('Multiple environments are not supported for this container.');
+    }
+
+    async stringify(): Promise<string> {
+        return this.fileContents;
+    }
+
+    async commit(): Promise<void> {
+        this.fileContents = JSON.stringify(this._current, null, 4);
+        this._dirty = false;
+    }
+
+    get name() {
+        return this._current.name;
+    }
+
+    set name(value: string) {
+        this._current.name = value;
+        this._dirty = true;
+    }
+
+    get variables() {
+        return this._current.values.map(p => {
+            const { enabled, key, value } = p;
+            return {
+                description: '',
+                isActive: enabled,
+                key,
+                value,
+            };
+        });
+    }
+
+    set variables(value: INetConsoleParameter[]) {
+        this._current.values = value.map(p => {
+            const { isActive, key, value } = p;
+            return {
+                enabled: isActive,
+                key,
+                value,
+            };
+        });
+        this._dirty = true;
+    }
+}

--- a/packages/network-console-shared/src/file_io/postman/v2.1/environment-format.ts
+++ b/packages/network-console-shared/src/file_io/postman/v2.1/environment-format.ts
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { uuid } from 'uuidv4';
+import {
+    IEnvironmentFormat,
+    IEnvironmentContainerAdapter,
+} from '../../interfaces';
+import { EnvironmentContainerAdapter } from './environment-container-adapter';
+
+export interface IPostmanEnvironmentFile {
+    id: string;
+    name: string;
+    values: Array<{
+        key: string;
+        value: string;
+        enabled: boolean;
+    }>;
+    _postman_variable_scope: 'environment';
+    _postman_exported_at: string;
+    _postman_exported_using: string;
+}
+
+export class EnvironmentFormat implements IEnvironmentFormat {
+    public readonly formatId = 'postman-v2.1-env';
+    public readonly canWrite = true;
+
+    private static _nextNewEnvironmentId = 0;
+
+    constructor() {}
+
+    async createEnvironmentContainer(name: string): Promise<IEnvironmentContainerAdapter> {
+        const DEFAULT_ENVIRONMENT: IPostmanEnvironmentFile = {
+            id: uuid(),
+            name,
+            values: [],
+            _postman_variable_scope: 'environment',
+            _postman_exported_at: new Date().toISOString(),
+            _postman_exported_using: 'edge-devtools-network-console/0.9.2-preview',
+        };
+
+        const id = `postman-v2.1-format-new-environment-${EnvironmentFormat._nextNewEnvironmentId++}`;
+        return new EnvironmentContainerAdapter(this, id, JSON.stringify(DEFAULT_ENVIRONMENT, null, 4));
+    }
+
+    async parse(id: string, contents: string): Promise<IEnvironmentContainerAdapter> {
+        return new EnvironmentContainerAdapter(this, id, contents);
+    }
+
+    async tryParse(id: string, contents: string): Promise<IEnvironmentContainerAdapter | null> {
+        try {
+            return await this.parse(id, contents);
+        }
+        catch (_err) {
+            return null;
+        }
+    }
+}

--- a/packages/network-console-shared/src/file_io/postman/v2.1/test/cases/starting-case.postman_environment.json
+++ b/packages/network-console-shared/src/file_io/postman/v2.1/test/cases/starting-case.postman_environment.json
@@ -1,0 +1,14 @@
+{
+	"id": "ac379676-3c24-422f-9834-05fc771c54f8",
+	"name": "Starting case",
+	"values": [
+		{
+			"key": "uriroot",
+			"value": "http://localhost:3000",
+			"enabled": true
+		}
+	],
+	"_postman_variable_scope": "environment",
+	"_postman_exported_at": "2020-09-02T19:46:06.308Z",
+	"_postman_exported_using": "Postman/7.31.1"
+}

--- a/packages/network-console-shared/src/file_io/postman/v2.1/test/environment-format.test.ts
+++ b/packages/network-console-shared/src/file_io/postman/v2.1/test/environment-format.test.ts
@@ -1,0 +1,152 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { ImportMock } from 'ts-mock-imports';
+import chai, { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import 'mocha';
+import Sinon, { useFakeTimers } from 'sinon';
+import * as uuidv4Module from 'uuidv4';
+chai.use(chaiAsPromised);
+
+import { EnvironmentFormat, IPostmanEnvironmentFile } from '../environment-format';
+
+describe('network-console-shared/src/file_io/native/environment-format', () => {
+    let clock: Sinon.SinonFakeTimers;
+    before(() => {
+        const uuidv4Mock = ImportMock.mockFunction(uuidv4Module, 'uuid');
+        uuidv4Mock.returns('12345678-1234-2345-3456-1234567890ab');
+        clock = useFakeTimers(Date.now());
+    });
+
+    after(() => {
+        ImportMock.restore();
+        clock.restore();
+    });
+
+    it('creates a default environment and serializes it correctly', async () => {
+        const format = new EnvironmentFormat();
+        const name = 'Empty test environment';
+        const expected: IPostmanEnvironmentFile = {
+            id: '12345678-1234-2345-3456-1234567890ab',
+            name,
+            values: [],
+            _postman_variable_scope: 'environment',
+	        _postman_exported_at: new Date().toISOString(),
+	        _postman_exported_using: 'edge-devtools-network-console/0.9.2-preview'
+        };
+
+        const collection = await format.createEnvironmentContainer(name);
+        expect(await collection.stringify()).to.deep.equal(JSON.stringify(expected, null, 4));
+    });
+
+    describe('Variations of EnvironmentFormat#parse failures', () => {
+        it('Throws if the root lacks an ID field', () => {
+            async function test() {
+                const format = new EnvironmentFormat();
+                const expected = JSON.stringify({
+                    name: 'Known bad',
+                    values: [],
+                }, null, 4);
+                await format.parse('Known bad', expected);
+            }
+
+            return expect(test()).to.eventually.be.rejectedWith(RangeError);
+        });
+
+        it('Throws if the root lacks a name field', () => {
+            async function test() {
+                const format = new EnvironmentFormat();
+                const expected = JSON.stringify({
+                    id: '01234567-89ab-cdef-0123-456789abcdef',
+                    environments: [],
+                }, null, 4);
+                await format.parse('Known bad', expected);
+            }
+
+            return expect(test()).to.eventually.be.rejectedWith(RangeError);
+        });
+
+        it('Throws if the root lacks a values field', () => {
+            async function test() {
+                const format = new EnvironmentFormat();
+                const expected = JSON.stringify({
+                    id: '01234567-89ab-cdef-0123-456789abcdef',
+                    name: 'Known bad',
+                }, null, 4);
+                await format.parse('Known bad', expected);
+            }
+
+            return expect(test()).to.eventually.be.rejectedWith(RangeError);
+        });
+
+        it('Throws if the values field is not an array', () => {
+            async function test() {
+                const format = new EnvironmentFormat();
+                const expected = JSON.stringify({
+                    id: '01234567-89ab-cdef-0123-456789abcdef',
+                    name: 'Known bad',
+                    values: 'This should be an array, not a string',
+                }, null, 4);
+                await format.parse('Known bad', expected);
+            }
+
+            return expect(test()).to.eventually.be.rejectedWith(RangeError);
+        });
+    });
+
+    describe('Variations of EnvironmentFormat#tryParse failures', () => {
+        it('Throws if the root lacks an ID field', () => {
+            async function test() {
+                const format = new EnvironmentFormat();
+                const expected = JSON.stringify({
+                    name: 'Known bad',
+                    values: [],
+                }, null, 4);
+                return await format.tryParse('Known bad', expected);
+            }
+
+            return expect(test()).to.eventually.be.null;
+        });
+
+        it('Throws if the root lacks a name field', () => {
+            async function test() {
+                const format = new EnvironmentFormat();
+                const expected = JSON.stringify({
+                    id: '01234567-89ab-cdef-0123-456789abcdef',
+                    environments: [],
+                }, null, 4);
+                return await format.tryParse('Known bad', expected);
+            }
+
+            return expect(test()).to.eventually.be.null;
+        });
+
+        it('Throws if the root lacks a values field', () => {
+            async function test() {
+                const format = new EnvironmentFormat();
+                const expected = JSON.stringify({
+                    id: '01234567-89ab-cdef-0123-456789abcdef',
+                    name: 'Known bad',
+                }, null, 4);
+                return await format.tryParse('Known bad', expected);
+            }
+
+            return expect(test()).to.eventually.be.null;
+        });
+
+        it('Throws if the values field is not an array', () => {
+            async function test() {
+                const format = new EnvironmentFormat();
+                const expected = JSON.stringify({
+                    id: '01234567-89ab-cdef-0123-456789abcdef',
+                    name: 'Known bad',
+                    values: 'This should be an array, not a string',
+                }, null, 4);
+                return await format.tryParse('Known bad', expected);
+            }
+
+            return expect(test()).to.eventually.be.null;
+        });
+    });
+});

--- a/packages/network-console-shared/src/file_io/serialize.ts
+++ b/packages/network-console-shared/src/file_io/serialize.ts
@@ -92,7 +92,7 @@ export function serializeBodyComponents(src: INetConsoleBodyComponents): INetCon
         bodySelection,
     };
 
-    if (src.rawTextBody) {
+    if (src.rawTextBody && src.rawTextBody.text !== '') {
         const { contentType, text } = src.rawTextBody;
         result.rawTextBody = {
             contentType,
@@ -100,11 +100,11 @@ export function serializeBodyComponents(src: INetConsoleBodyComponents): INetCon
         };
     }
 
-    if (src.xWwwFormUrlencoded) {
+    if (src.xWwwFormUrlencoded && src.xWwwFormUrlencoded.length) {
         result.xWwwFormUrlencoded = src.xWwwFormUrlencoded.map(serializeParameter);
     }
 
-    if (src.formData) {
+    if (src.formData && src.formData.length) {
         result.formData = src.formData.map(serializeFormParameter);
     }
 

--- a/packages/network-console-shared/src/file_io/test/cases/expected.converted-from-postman-v2.1.nc.json
+++ b/packages/network-console-shared/src/file_io/test/cases/expected.converted-from-postman-v2.1.nc.json
@@ -1,0 +1,314 @@
+{
+    "meta": {
+        "networkConsoleCollectionVersion": "0.9.2-preview"
+    },
+    "name": "Test collection",
+    "entries": [
+        {
+            "request": {
+                "authorization": {
+                    "type": "inherit"
+                },
+                "body": {
+                    "content": ""
+                },
+                "bodyComponents": {
+                    "bodySelection": "none"
+                },
+                "description": "Request #1 is the first request.",
+                "headers": [],
+                "name": "First request",
+                "queryParameters": [],
+                "routeParameters": [],
+                "url": "http://localhost:9999/",
+                "verb": "GET"
+            }
+        },
+        {
+            "request": {
+                "authorization": {
+                    "type": "token",
+                    "token": {
+                        "token": "1234abcd"
+                    }
+                },
+                "body": {
+                    "content": ""
+                },
+                "bodyComponents": {
+                    "bodySelection": "raw",
+                    "rawTextBody": {
+                        "contentType": "",
+                        "text": "Hello, world."
+                    }
+                },
+                "description": "Request #2 is the second request.",
+                "headers": [
+                    {
+                        "description": "The API key of the request.",
+                        "isActive": true,
+                        "key": "X-ApiKey",
+                        "value": "not-really-an-api-key"
+                    }
+                ],
+                "name": "Second request",
+                "queryParameters": [],
+                "routeParameters": [],
+                "url": "http://localhost:9999/",
+                "verb": "GET"
+            }
+        },
+        {
+            "name": "Test folder",
+            "auth": {
+                "type": "basic",
+                "basic": {
+                    "username": "user",
+                    "password": "pass",
+                    "showPassword": false
+                }
+            },
+            "entries": [
+                {
+                    "name": "Another subfolder",
+                    "auth": {
+                        "type": "inherit"
+                    },
+                    "entries": [
+                        {
+                            "request": {
+                                "authorization": {
+                                    "type": "inherit"
+                                },
+                                "body": {
+                                    "content": ""
+                                },
+                                "bodyComponents": {
+                                    "bodySelection": "none"
+                                },
+                                "description": "Request #3 is the third request.",
+                                "headers": [],
+                                "name": "Third request",
+                                "queryParameters": [],
+                                "routeParameters": [
+                                    {
+                                        "description": "",
+                                        "isActive": true,
+                                        "key": "bar",
+                                        "value": "key-of-life"
+                                    },
+                                    {
+                                        "description": "",
+                                        "isActive": true,
+                                        "key": "baz",
+                                        "value": "42"
+                                    }
+                                ],
+                                "url": "http://localhost:9999/foo/:bar/:baz",
+                                "verb": "DELETE"
+                            }
+                        },
+                        {
+                            "request": {
+                                "authorization": {
+                                    "type": "inherit"
+                                },
+                                "body": {
+                                    "content": ""
+                                },
+                                "bodyComponents": {
+                                    "bodySelection": "none"
+                                },
+                                "description": "Request #3 is the third request.",
+                                "headers": [],
+                                "name": "Third request",
+                                "queryParameters": [],
+                                "routeParameters": [
+                                    {
+                                        "description": "",
+                                        "isActive": true,
+                                        "key": "bar",
+                                        "value": "key-of-life"
+                                    },
+                                    {
+                                        "description": "",
+                                        "isActive": true,
+                                        "key": "baz",
+                                        "value": "42"
+                                    }
+                                ],
+                                "url": "http://localhost:9999/foo/:bar/:baz",
+                                "verb": "DELETE"
+                            }
+                        },
+                        {
+                            "request": {
+                                "authorization": {
+                                    "type": "inherit"
+                                },
+                                "body": {
+                                    "content": ""
+                                },
+                                "bodyComponents": {
+                                    "bodySelection": "none"
+                                },
+                                "description": "Request #3 is the third request.",
+                                "headers": [],
+                                "name": "Third request",
+                                "queryParameters": [],
+                                "routeParameters": [
+                                    {
+                                        "description": "",
+                                        "isActive": true,
+                                        "key": "bar",
+                                        "value": "key-of-life"
+                                    },
+                                    {
+                                        "description": "",
+                                        "isActive": true,
+                                        "key": "baz",
+                                        "value": "42"
+                                    }
+                                ],
+                                "url": "http://localhost:9999/foo/:bar/:baz",
+                                "verb": "DELETE"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "request": {
+                        "authorization": {
+                            "type": "inherit"
+                        },
+                        "body": {
+                            "content": ""
+                        },
+                        "bodyComponents": {
+                            "bodySelection": "none"
+                        },
+                        "description": "Request #3 is the third request.",
+                        "headers": [],
+                        "name": "Third request",
+                        "queryParameters": [],
+                        "routeParameters": [
+                            {
+                                "description": "",
+                                "isActive": true,
+                                "key": "bar",
+                                "value": "key-of-life"
+                            },
+                            {
+                                "description": "",
+                                "isActive": true,
+                                "key": "baz",
+                                "value": "42"
+                            }
+                        ],
+                        "url": "http://localhost:9999/foo/:bar/:baz",
+                        "verb": "DELETE"
+                    }
+                },
+                {
+                    "request": {
+                        "authorization": {
+                            "type": "inherit"
+                        },
+                        "body": {
+                            "content": ""
+                        },
+                        "bodyComponents": {
+                            "bodySelection": "none"
+                        },
+                        "description": "Request #3 is the third request.",
+                        "headers": [],
+                        "name": "Third request",
+                        "queryParameters": [],
+                        "routeParameters": [
+                            {
+                                "description": "",
+                                "isActive": true,
+                                "key": "bar",
+                                "value": "key-of-life"
+                            },
+                            {
+                                "description": "",
+                                "isActive": true,
+                                "key": "baz",
+                                "value": "42"
+                            }
+                        ],
+                        "url": "http://localhost:9999/foo/:bar/:baz",
+                        "verb": "DELETE"
+                    }
+                },
+                {
+                    "request": {
+                        "authorization": {
+                            "type": "inherit"
+                        },
+                        "body": {
+                            "content": ""
+                        },
+                        "bodyComponents": {
+                            "bodySelection": "none"
+                        },
+                        "description": "Request #3 is the third request.",
+                        "headers": [],
+                        "name": "Third request",
+                        "queryParameters": [],
+                        "routeParameters": [
+                            {
+                                "description": "",
+                                "isActive": true,
+                                "key": "bar",
+                                "value": "key-of-life"
+                            },
+                            {
+                                "description": "",
+                                "isActive": true,
+                                "key": "baz",
+                                "value": "42"
+                            }
+                        ],
+                        "url": "http://localhost:9999/foo/:bar/:baz",
+                        "verb": "DELETE"
+                    }
+                }
+            ]
+        },
+        {
+            "request": {
+                "authorization": {
+                    "type": "inherit"
+                },
+                "body": {
+                    "content": ""
+                },
+                "bodyComponents": {
+                    "bodySelection": "none"
+                },
+                "description": "Request #3 is the third request.",
+                "headers": [],
+                "name": "Third request",
+                "queryParameters": [],
+                "routeParameters": [
+                    {
+                        "description": "",
+                        "isActive": true,
+                        "key": "bar",
+                        "value": "key-of-life"
+                    },
+                    {
+                        "description": "",
+                        "isActive": true,
+                        "key": "baz",
+                        "value": "42"
+                    }
+                ],
+                "url": "http://localhost:9999/foo/:bar/:baz",
+                "verb": "DELETE"
+            }
+        }
+    ]
+}

--- a/packages/network-console-shared/src/file_io/test/cases/expected.native-to-postman.postman_environment.json
+++ b/packages/network-console-shared/src/file_io/test/cases/expected.native-to-postman.postman_environment.json
@@ -1,0 +1,12 @@
+{
+    "id": "12345678-1234-2345-3456-1234567890ab",
+    "name": "Default",
+    "values": [{
+        "enabled": true,
+        "key": "baseUri",
+        "value": "https://www.contoso.com/"
+    }],
+    "_postman_variable_scope": "environment",
+    "_postman_exported_at": "2020-09-03T04:30:00.000Z",
+    "_postman_exported_using": "edge-devtools-network-console/0.9.2-preview"
+}

--- a/packages/network-console-shared/src/file_io/test/cases/expected.openapi-to-postman.postman_environment.json
+++ b/packages/network-console-shared/src/file_io/test/cases/expected.openapi-to-postman.postman_environment.json
@@ -1,0 +1,12 @@
+{
+    "id": "12345678-1234-2345-3456-1234567890ab",
+    "name": "https",
+    "values": [{
+        "enabled": true,
+        "key": "baseUri",
+        "value": "https://petstore.swagger.io/v2"
+    }],
+    "_postman_variable_scope": "environment",
+    "_postman_exported_at": "2020-09-03T04:30:00.000Z",
+    "_postman_exported_using": "edge-devtools-network-console/0.9.2-preview"
+}

--- a/packages/network-console-shared/src/file_io/test/cases/expected.petstore-swagger-io.nc.json
+++ b/packages/network-console-shared/src/file_io/test/cases/expected.petstore-swagger-io.nc.json
@@ -15,13 +15,7 @@
                         "queryParameters": [],
                         "routeParameters": [],
                         "bodyComponents": {
-                            "bodySelection": "none",
-                            "formData": [],
-                            "rawTextBody": {
-                                "contentType": "application/json",
-                                "text": ""
-                            },
-                            "xWwwFormUrlencoded": []
+                            "bodySelection": "none"
                         },
                         "authorization": {
                             "type": "inherit"
@@ -41,13 +35,7 @@
                         "queryParameters": [],
                         "routeParameters": [],
                         "bodyComponents": {
-                            "bodySelection": "none",
-                            "formData": [],
-                            "rawTextBody": {
-                                "contentType": "application/json",
-                                "text": ""
-                            },
-                            "xWwwFormUrlencoded": []
+                            "bodySelection": "none"
                         },
                         "authorization": {
                             "type": "inherit"
@@ -82,13 +70,7 @@
                         ],
                         "routeParameters": [],
                         "bodyComponents": {
-                            "bodySelection": "none",
-                            "formData": [],
-                            "rawTextBody": {
-                                "contentType": "application/json",
-                                "text": ""
-                            },
-                            "xWwwFormUrlencoded": []
+                            "bodySelection": "none"
                         },
                         "authorization": {
                             "type": "inherit"
@@ -123,13 +105,7 @@
                         ],
                         "routeParameters": [],
                         "bodyComponents": {
-                            "bodySelection": "none",
-                            "formData": [],
-                            "rawTextBody": {
-                                "contentType": "application/json",
-                                "text": ""
-                            },
-                            "xWwwFormUrlencoded": []
+                            "bodySelection": "none"
                         },
                         "authorization": {
                             "type": "inherit"
@@ -164,13 +140,7 @@
                             }
                         ],
                         "bodyComponents": {
-                            "bodySelection": "none",
-                            "formData": [],
-                            "rawTextBody": {
-                                "contentType": "application/json",
-                                "text": ""
-                            },
-                            "xWwwFormUrlencoded": []
+                            "bodySelection": "none"
                         },
                         "authorization": {
                             "type": "inherit"
@@ -197,13 +167,7 @@
                             }
                         ],
                         "bodyComponents": {
-                            "bodySelection": "none",
-                            "formData": [],
-                            "rawTextBody": {
-                                "contentType": "application/json",
-                                "text": ""
-                            },
-                            "xWwwFormUrlencoded": []
+                            "bodySelection": "none"
                         },
                         "authorization": {
                             "type": "inherit"
@@ -230,13 +194,7 @@
                             }
                         ],
                         "bodyComponents": {
-                            "bodySelection": "none",
-                            "formData": [],
-                            "rawTextBody": {
-                                "contentType": "application/x-www-form-urlencoded",
-                                "text": ""
-                            },
-                            "xWwwFormUrlencoded": []
+                            "bodySelection": "none"
                         },
                         "authorization": {
                             "type": "inherit"
@@ -271,13 +229,7 @@
                             }
                         ],
                         "bodyComponents": {
-                            "bodySelection": "none",
-                            "formData": [],
-                            "rawTextBody": {
-                                "contentType": "multipart/form-data",
-                                "text": ""
-                            },
-                            "xWwwFormUrlencoded": []
+                            "bodySelection": "none"
                         },
                         "authorization": {
                             "type": "inherit"
@@ -305,13 +257,7 @@
                         "queryParameters": [],
                         "routeParameters": [],
                         "bodyComponents": {
-                            "bodySelection": "none",
-                            "formData": [],
-                            "rawTextBody": {
-                                "contentType": "application/json",
-                                "text": ""
-                            },
-                            "xWwwFormUrlencoded": []
+                            "bodySelection": "none"
                         },
                         "authorization": {
                             "type": "inherit"
@@ -339,13 +285,7 @@
                         "queryParameters": [],
                         "routeParameters": [],
                         "bodyComponents": {
-                            "bodySelection": "none",
-                            "formData": [],
-                            "rawTextBody": {
-                                "contentType": "application/json",
-                                "text": ""
-                            },
-                            "xWwwFormUrlencoded": []
+                            "bodySelection": "none"
                         },
                         "authorization": {
                             "type": "inherit"
@@ -380,13 +320,7 @@
                             }
                         ],
                         "bodyComponents": {
-                            "bodySelection": "none",
-                            "formData": [],
-                            "rawTextBody": {
-                                "contentType": "application/json",
-                                "text": ""
-                            },
-                            "xWwwFormUrlencoded": []
+                            "bodySelection": "none"
                         },
                         "authorization": {
                             "type": "inherit"
@@ -413,13 +347,7 @@
                             }
                         ],
                         "bodyComponents": {
-                            "bodySelection": "none",
-                            "formData": [],
-                            "rawTextBody": {
-                                "contentType": "application/json",
-                                "text": ""
-                            },
-                            "xWwwFormUrlencoded": []
+                            "bodySelection": "none"
                         },
                         "authorization": {
                             "type": "inherit"
@@ -447,13 +375,7 @@
                         "queryParameters": [],
                         "routeParameters": [],
                         "bodyComponents": {
-                            "bodySelection": "none",
-                            "formData": [],
-                            "rawTextBody": {
-                                "contentType": "application/json",
-                                "text": ""
-                            },
-                            "xWwwFormUrlencoded": []
+                            "bodySelection": "none"
                         },
                         "authorization": {
                             "type": "inherit"
@@ -481,13 +403,7 @@
                         "queryParameters": [],
                         "routeParameters": [],
                         "bodyComponents": {
-                            "bodySelection": "none",
-                            "formData": [],
-                            "rawTextBody": {
-                                "contentType": "application/json",
-                                "text": ""
-                            },
-                            "xWwwFormUrlencoded": []
+                            "bodySelection": "none"
                         },
                         "authorization": {
                             "type": "inherit"
@@ -515,13 +431,7 @@
                         "queryParameters": [],
                         "routeParameters": [],
                         "bodyComponents": {
-                            "bodySelection": "none",
-                            "formData": [],
-                            "rawTextBody": {
-                                "contentType": "application/json",
-                                "text": ""
-                            },
-                            "xWwwFormUrlencoded": []
+                            "bodySelection": "none"
                         },
                         "authorization": {
                             "type": "inherit"
@@ -562,13 +472,7 @@
                         ],
                         "routeParameters": [],
                         "bodyComponents": {
-                            "bodySelection": "none",
-                            "formData": [],
-                            "rawTextBody": {
-                                "contentType": "application/json",
-                                "text": ""
-                            },
-                            "xWwwFormUrlencoded": []
+                            "bodySelection": "none"
                         },
                         "authorization": {
                             "type": "inherit"
@@ -596,13 +500,7 @@
                         "queryParameters": [],
                         "routeParameters": [],
                         "bodyComponents": {
-                            "bodySelection": "none",
-                            "formData": [],
-                            "rawTextBody": {
-                                "contentType": "application/json",
-                                "text": ""
-                            },
-                            "xWwwFormUrlencoded": []
+                            "bodySelection": "none"
                         },
                         "authorization": {
                             "type": "inherit"
@@ -637,13 +535,7 @@
                             }
                         ],
                         "bodyComponents": {
-                            "bodySelection": "none",
-                            "formData": [],
-                            "rawTextBody": {
-                                "contentType": "application/json",
-                                "text": ""
-                            },
-                            "xWwwFormUrlencoded": []
+                            "bodySelection": "none"
                         },
                         "authorization": {
                             "type": "inherit"
@@ -670,13 +562,7 @@
                             }
                         ],
                         "bodyComponents": {
-                            "bodySelection": "none",
-                            "formData": [],
-                            "rawTextBody": {
-                                "contentType": "application/json",
-                                "text": ""
-                            },
-                            "xWwwFormUrlencoded": []
+                            "bodySelection": "none"
                         },
                         "authorization": {
                             "type": "inherit"
@@ -703,13 +589,7 @@
                             }
                         ],
                         "bodyComponents": {
-                            "bodySelection": "none",
-                            "formData": [],
-                            "rawTextBody": {
-                                "contentType": "application/json",
-                                "text": ""
-                            },
-                            "xWwwFormUrlencoded": []
+                            "bodySelection": "none"
                         },
                         "authorization": {
                             "type": "inherit"

--- a/packages/network-console-shared/src/file_io/test/cases/expected.petstore-swagger-io.ncenv.json
+++ b/packages/network-console-shared/src/file_io/test/cases/expected.petstore-swagger-io.ncenv.json
@@ -1,0 +1,26 @@
+{
+    "meta": {
+        "networkConsoleEnvironmentVersion": "0.9.2-preview"
+    },
+    "name": "Swagger Petstore (OpenAPI)",
+    "environments": [
+        {
+            "name": "https",
+            "variables": [{
+                "description": "Auto-generated from the OpenAPI document to access the root of the API service",
+                "isActive": true,
+                "key": "baseUri",
+                "value": "https://petstore.swagger.io/v2"
+            }]
+        },
+        {
+            "name": "http",
+            "variables": [{
+                "description": "Auto-generated from the OpenAPI document to access the root of the API service",
+                "isActive": true,
+                "key": "baseUri",
+                "value": "http://petstore.swagger.io/v2"
+            }]
+        }
+    ]
+}

--- a/packages/network-console-shared/src/file_io/test/cases/expected.petstore-swagger-io.postman_collection.json
+++ b/packages/network-console-shared/src/file_io/test/cases/expected.petstore-swagger-io.postman_collection.json
@@ -11,11 +11,7 @@
             "item": [
                 {
                     "request": {
-                        "body": {
-                            "formdata": [],
-                            "raw": "",
-                            "urlencoded": []
-                        },
+                        "body": {},
                         "header": [],
                         "description": "",
                         "url": {
@@ -33,11 +29,7 @@
                 },
                 {
                     "request": {
-                        "body": {
-                            "formdata": [],
-                            "raw": "",
-                            "urlencoded": []
-                        },
+                        "body": {},
                         "header": [],
                         "description": "",
                         "url": {
@@ -60,11 +52,7 @@
             "item": [
                 {
                     "request": {
-                        "body": {
-                            "formdata": [],
-                            "raw": "",
-                            "urlencoded": []
-                        },
+                        "body": {},
                         "header": [],
                         "description": "",
                         "url": {
@@ -96,11 +84,7 @@
             "item": [
                 {
                     "request": {
-                        "body": {
-                            "formdata": [],
-                            "raw": "",
-                            "urlencoded": []
-                        },
+                        "body": {},
                         "header": [],
                         "description": "",
                         "url": {
@@ -132,11 +116,7 @@
             "item": [
                 {
                     "request": {
-                        "body": {
-                            "formdata": [],
-                            "raw": "",
-                            "urlencoded": []
-                        },
+                        "body": {},
                         "header": [],
                         "description": "",
                         "url": {
@@ -164,11 +144,7 @@
                 },
                 {
                     "request": {
-                        "body": {
-                            "formdata": [],
-                            "raw": "",
-                            "urlencoded": []
-                        },
+                        "body": {},
                         "header": [],
                         "description": "",
                         "url": {
@@ -196,11 +172,7 @@
                 },
                 {
                     "request": {
-                        "body": {
-                            "formdata": [],
-                            "raw": "",
-                            "urlencoded": []
-                        },
+                        "body": {},
                         "header": [],
                         "description": "",
                         "url": {
@@ -233,11 +205,7 @@
             "item": [
                 {
                     "request": {
-                        "body": {
-                            "formdata": [],
-                            "raw": "",
-                            "urlencoded": []
-                        },
+                        "body": {},
                         "header": [],
                         "description": "",
                         "url": {
@@ -271,11 +239,7 @@
             "item": [
                 {
                     "request": {
-                        "body": {
-                            "formdata": [],
-                            "raw": "",
-                            "urlencoded": []
-                        },
+                        "body": {},
                         "header": [],
                         "description": "",
                         "url": {
@@ -299,11 +263,7 @@
             "item": [
                 {
                     "request": {
-                        "body": {
-                            "formdata": [],
-                            "raw": "",
-                            "urlencoded": []
-                        },
+                        "body": {},
                         "header": [],
                         "description": "",
                         "url": {
@@ -327,11 +287,7 @@
             "item": [
                 {
                     "request": {
-                        "body": {
-                            "formdata": [],
-                            "raw": "",
-                            "urlencoded": []
-                        },
+                        "body": {},
                         "header": [],
                         "description": "",
                         "url": {
@@ -360,11 +316,7 @@
                 },
                 {
                     "request": {
-                        "body": {
-                            "formdata": [],
-                            "raw": "",
-                            "urlencoded": []
-                        },
+                        "body": {},
                         "header": [],
                         "description": "",
                         "url": {
@@ -398,11 +350,7 @@
             "item": [
                 {
                     "request": {
-                        "body": {
-                            "formdata": [],
-                            "raw": "",
-                            "urlencoded": []
-                        },
+                        "body": {},
                         "header": [],
                         "description": "",
                         "url": {
@@ -425,11 +373,7 @@
             "item": [
                 {
                     "request": {
-                        "body": {
-                            "formdata": [],
-                            "raw": "",
-                            "urlencoded": []
-                        },
+                        "body": {},
                         "header": [],
                         "description": "",
                         "url": {
@@ -453,11 +397,7 @@
             "item": [
                 {
                     "request": {
-                        "body": {
-                            "formdata": [],
-                            "raw": "",
-                            "urlencoded": []
-                        },
+                        "body": {},
                         "header": [],
                         "description": "",
                         "url": {
@@ -481,11 +421,7 @@
             "item": [
                 {
                     "request": {
-                        "body": {
-                            "formdata": [],
-                            "raw": "",
-                            "urlencoded": []
-                        },
+                        "body": {},
                         "header": [],
                         "description": "",
                         "url": {
@@ -523,11 +459,7 @@
             "item": [
                 {
                     "request": {
-                        "body": {
-                            "formdata": [],
-                            "raw": "",
-                            "urlencoded": []
-                        },
+                        "body": {},
                         "header": [],
                         "description": "",
                         "url": {
@@ -551,11 +483,7 @@
             "item": [
                 {
                     "request": {
-                        "body": {
-                            "formdata": [],
-                            "raw": "",
-                            "urlencoded": []
-                        },
+                        "body": {},
                         "header": [],
                         "description": "",
                         "url": {
@@ -583,11 +511,7 @@
                 },
                 {
                     "request": {
-                        "body": {
-                            "formdata": [],
-                            "raw": "",
-                            "urlencoded": []
-                        },
+                        "body": {},
                         "header": [],
                         "description": "",
                         "url": {
@@ -615,11 +539,7 @@
                 },
                 {
                     "request": {
-                        "body": {
-                            "formdata": [],
-                            "raw": "",
-                            "urlencoded": []
-                        },
+                        "body": {},
                         "header": [],
                         "description": "",
                         "url": {

--- a/packages/network-console-shared/src/file_io/test/cases/expected.postman-to-native.ncenv.json
+++ b/packages/network-console-shared/src/file_io/test/cases/expected.postman-to-native.ncenv.json
@@ -1,0 +1,17 @@
+{
+    "meta": {
+        "networkConsoleEnvironmentVersion": "0.9.2-preview"
+    },
+    "name": "Starting Environment case",
+    "environments": [
+        {
+            "name": "Starting Environment case",
+            "variables": [{
+                "description": "",
+                "isActive": true,
+                "key": "baseUri",
+                "value": "https://www.contoso.com/"
+            }]
+        }
+    ]
+}

--- a/packages/network-console-shared/src/file_io/test/cases/multiple-environments.ncenv.json
+++ b/packages/network-console-shared/src/file_io/test/cases/multiple-environments.ncenv.json
@@ -1,0 +1,26 @@
+{
+    "meta": {
+        "networkConsoleEnvironmentVersion": "0.9.2-preview"
+    },
+    "name": "Multiple Environments case",
+    "environments": [
+        {
+            "name": "Default",
+            "variables": [{
+                "description": "The root component of the URI",
+                "isActive": true,
+                "key": "baseUri",
+                "value": "https://www.contoso.com/"
+            }]
+        },
+        {
+            "name": "Localhost",
+            "variables": [{
+                "description": "The root component of the URI",
+                "isActive": true,
+                "key": "baseUri",
+                "value": "http://localhost:8888/"
+            }]
+        }
+    ]
+}

--- a/packages/network-console-shared/src/file_io/test/cases/starting-case.ncenv.json
+++ b/packages/network-console-shared/src/file_io/test/cases/starting-case.ncenv.json
@@ -1,0 +1,17 @@
+{
+    "meta": {
+        "networkConsoleEnvironmentVersion": "0.9.2-preview"
+    },
+    "name": "Starting Environment case",
+    "environments": [
+        {
+            "name": "Default",
+            "variables": [{
+                "description": "The root component of the URI",
+                "isActive": true,
+                "key": "baseUri",
+                "value": "https://www.contoso.com/"
+            }]
+        }
+    ]
+}

--- a/packages/network-console-shared/src/file_io/test/cases/starting-case.postman_environment.json
+++ b/packages/network-console-shared/src/file_io/test/cases/starting-case.postman_environment.json
@@ -1,0 +1,12 @@
+{
+    "id": "12345678-1234-2345-3456-1234567890ab",
+    "name": "Starting Environment case",
+    "values": [{
+        "enabled": true,
+        "key": "baseUri",
+        "value": "https://www.contoso.com/"
+    }],
+    "_postman_variable_scope": "environment",
+    "_postman_exported_at": "2020-09-03T04:30:00.000Z",
+    "_postman_exported_using": "edge-devtools-network-console/0.9.2-preview"
+}

--- a/packages/network-console-shared/src/file_io/test/convert.test.ts
+++ b/packages/network-console-shared/src/file_io/test/convert.test.ts
@@ -1,80 +1,172 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import fs from 'fs';
 import { ImportMock } from 'ts-mock-imports';
 import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import 'mocha';
 import * as uuidv4Module from 'uuidv4';
+import Sinon, { useFakeTimers } from 'sinon';
 
 chai.use(chaiAsPromised);
 
-import formats from '../index';
-import { convertFormats } from '../convert';
+import formats, { environmentFormats } from '../index';
+import { convertFormats, convertEnvironment } from '../convert';
 
 import { getContents } from '../../test-util/read-collection';
 import jsonCompare from '../../test-util/json-compare';
 
-async function loadKnownGoodNativeFormat() {
-    const fileContents = await getContents('src/file_io/native/test/cases/starting-case-with-auths.nc.json');
-    return await formats['nc-native'].parse('starting-case.nc.json', fileContents);
-}
-
-async function loadKnownGoodPostman2_1Format() {
-    const fileContents = await getContents('src/file_io/postman/v2.1/test/cases/starting-case.postman_collection.json');
-    return await formats['postman-v2.1'].parse('starting-case.postman_collection.json', fileContents);
-}
-
-async function loadKnownGoodOpenAPIV2Format() {
-    const fileContents = await getContents('src/file_io/openapi/v2/test/cases/petstore-swagger-io.json');
-    return await formats['openapi'].parse('petstore-swagger-io.json', fileContents);
-}
-
 describe('file_io/convert.ts', () => {
-    before(() => {
-        const uuidv4Mock = ImportMock.mockFunction(uuidv4Module, 'uuid');
-        uuidv4Mock.returns('12345678-1234-2345-3456-1234567890ab');
-    });
-
-    after(() => {
-        ImportMock.restore();
-    });
-
-    it('Fails if the destination format is readonly.', async () => {
-        async function test() {
-            const src = await loadKnownGoodNativeFormat();
-            await convertFormats(src, formats.openapi);
+    describe('Collections', () => {
+        async function loadKnownGoodNativeFormat() {
+            const fileContents = await getContents('src/file_io/native/test/cases/starting-case-with-auths.nc.json');
+            return await formats['nc-native'].parse('starting-case.nc.json', fileContents);
         }
-        await expect(test()).to.eventually.be.rejectedWith(RangeError);
+
+        async function loadKnownGoodPostman2_1Format() {
+            const fileContents = await getContents('src/file_io/postman/v2.1/test/cases/starting-case.postman_collection.json');
+            return await formats['postman-v2.1'].parse('starting-case.postman_collection.json', fileContents);
+        }
+
+        async function loadKnownGoodOpenAPIV2Format() {
+            const fileContents = await getContents('src/file_io/openapi/v2/test/cases/petstore-swagger-io.json');
+            return await formats['openapi'].parse('petstore-swagger-io.json', fileContents);
+        }
+
+        before(() => {
+            const uuidv4Mock = ImportMock.mockFunction(uuidv4Module, 'uuid');
+            uuidv4Mock.returns('12345678-1234-2345-3456-1234567890ab');
+        });
+
+        after(() => {
+            ImportMock.restore();
+        });
+
+        it('Fails if the destination format is readonly.', async () => {
+            async function test() {
+                const src = await loadKnownGoodNativeFormat();
+                await convertFormats(src, formats.openapi);
+            }
+            await expect(test()).to.eventually.be.rejectedWith(RangeError);
+        });
+
+        it('Successfully converts NC Native to Postman v2.1.', async () => {
+            const src = await loadKnownGoodNativeFormat();
+            const result = await convertFormats(src, formats['postman-v2.1']);
+
+            const expected = await getContents('src/file_io/test/cases/converted-from-nc-native.postman_collection.json');
+            jsonCompare(await result.stringify(), expected);
+        });
+
+        it('Successfully converts Postman v2.1 to NC Native.', async () => {
+            const src = await loadKnownGoodPostman2_1Format();
+            await convertFormats(src, formats['nc-native']);
+        });
+
+        it('Successfully converts OpenAPI v2 to NC Native.', async () => {
+            const src = await loadKnownGoodOpenAPIV2Format();
+            const result = await convertFormats(src, formats['nc-native']);
+
+            const expected = await getContents('src/file_io/test/cases/expected.petstore-swagger-io.nc.json');
+            jsonCompare(await result.stringify(), expected);
+        });
+
+        it('Successfully converts OpenAPI v2 to Postman v2.1.', async () => {
+            const src = await loadKnownGoodOpenAPIV2Format();
+            const result = await convertFormats(src, formats['postman-v2.1']);
+
+            const expected = await getContents('src/file_io/test/cases/expected.petstore-swagger-io.postman_collection.json');
+            jsonCompare(await result.stringify(), expected);
+        });
     });
 
-    it('Successfully converts NC Native to Postman v2.1.', async () => {
-        const src = await loadKnownGoodNativeFormat();
-        const result = await convertFormats(src, formats['postman-v2.1']);
+    describe('Environments', () => {
+        async function loadKnownGoodNativeFormat() {
+            const fileContents = await getContents('src/file_io/test/cases/starting-case.ncenv.json');
+            return await environmentFormats['nc-native-env'].parse('starting-case.ncenv.json', fileContents);
+        }
 
-        const expected = await getContents('src/file_io/test/cases/converted-from-nc-native.postman_collection.json');
-        jsonCompare(await result.stringify(), expected);
-    });
+        async function loadKnownGoodNativeFormatWithMultipleEnvs() {
+            const fileContents = await getContents('src/file_io/test/cases/multiple-environments.ncenv.json');
+            return await environmentFormats['nc-native-env'].parse('multiple-environments.nc.json', fileContents);
+        }
 
-    it('Successfully converts Postman v2.1 to NC Native.', async () => {
-        const src = await loadKnownGoodPostman2_1Format();
-        await convertFormats(src, formats['nc-native']);
-    });
+        async function loadKnownGoodPostman2_1Format() {
+            const fileContents = await getContents('src/file_io/test/cases/starting-case.postman_environment.json');
+            return await environmentFormats['postman-v2.1-env'].parse('starting-case.postman_collection.json', fileContents);
+        }
 
-    it('Successfully converts OpenAPI v2 to NC Native.', async () => {
-        const src = await loadKnownGoodOpenAPIV2Format();
-        const result = await convertFormats(src, formats['nc-native']);
+        async function loadKnownGoodOpenAPIV2Format() {
+            const fileContents = await getContents('src/file_io/openapi/v2/test/cases/petstore-swagger-io.json');
+            return await environmentFormats['openapi-env'].parse('petstore-swagger-io.json', fileContents);
+        }
 
-        const expected = await getContents('src/file_io/test/cases/expected.petstore-swagger-io.nc.json');
-        jsonCompare(await result.stringify(), expected);
-    });
+        let clock: Sinon.SinonFakeTimers;
+        before(() => {
+            const uuidv4Mock = ImportMock.mockFunction(uuidv4Module, 'uuid');
+            uuidv4Mock.returns('12345678-1234-2345-3456-1234567890ab');
+            clock = useFakeTimers(1599107400000); // '2020-09-03T04:30:00.000Z'
+        });
 
-    it('Successfully converts OpenAPI v2 to Postman v2.1.', async () => {
-        const src = await loadKnownGoodOpenAPIV2Format();
-        const result = await convertFormats(src, formats['postman-v2.1']);
+        after(() => {
+            ImportMock.restore();
+            clock.restore();
+        });
 
-        const expected = await getContents('src/file_io/test/cases/expected.petstore-swagger-io.postman_collection.json');
-        jsonCompare(await result.stringify(), expected);
+        it('Fails if the destination format is readonly.', async () => {
+            async function test() {
+                const src = await loadKnownGoodNativeFormat();
+                await convertEnvironment(src, environmentFormats['openapi-env']);
+            }
+            await expect(test()).to.eventually.be.rejectedWith(RangeError);
+        });
+
+        it('Fails if the destination format does not support multiple environments but the default input has them.', async () => {
+            async function test() {
+                const src = await loadKnownGoodNativeFormatWithMultipleEnvs();
+                await convertEnvironment(src, environmentFormats['postman-v2.1-env']);
+            }
+            await expect(test()).to.eventually.be.rejectedWith(RangeError);
+        });
+
+        it('Fails if the destination format does not support multiple environments but the explicit input has them.', async () => {
+            async function test() {
+                const src = await loadKnownGoodNativeFormatWithMultipleEnvs();
+                await convertEnvironment(src, environmentFormats['postman-v2.1-env'], ...src.childIds);
+            }
+            await expect(test()).to.eventually.be.rejectedWith(RangeError);
+        });
+
+        it('Successfully converts NC Native to Postman v2.1.', async () => {
+            const src = await loadKnownGoodNativeFormat();
+            const result = await convertEnvironment(src, environmentFormats['postman-v2.1-env']);
+
+            const expected = await getContents('src/file_io/test/cases/expected.native-to-postman.postman_environment.json');
+            jsonCompare(await result.stringify(), expected);
+        });
+
+        it('Successfully converts Postman v2.1 to NC Native.', async () => {
+            const src = await loadKnownGoodPostman2_1Format();
+            const result = await convertEnvironment(src, environmentFormats['nc-native-env']);
+
+            const expected = await getContents('src/file_io/test/cases/expected.postman-to-native.ncenv.json');
+            jsonCompare(await result.stringify(), expected);
+        });
+
+        it('Successfully converts OpenAPI v2 to NC Native.', async () => {
+            const src = await loadKnownGoodOpenAPIV2Format();
+            const result = await convertEnvironment(src, environmentFormats['nc-native-env']);
+
+            const expected = await getContents('src/file_io/test/cases/expected.petstore-swagger-io.ncenv.json');
+            jsonCompare(await result.stringify(), expected);
+        });
+
+        it('Successfully converts OpenAPI v2 to Postman v2.1.', async () => {
+            const src = await loadKnownGoodOpenAPIV2Format();
+            const result = await convertEnvironment(src, environmentFormats['postman-v2.1-env'], src.childIds[0]);
+
+            const expected = await getContents('src/file_io/test/cases/expected.openapi-to-postman.postman_environment.json');
+            jsonCompare(await result.stringify(), expected);
+        });
     });
 });

--- a/packages/network-console-shared/src/file_io/test/convert.test.ts
+++ b/packages/network-console-shared/src/file_io/test/convert.test.ts
@@ -60,7 +60,10 @@ describe('file_io/convert.ts', () => {
 
         it('Successfully converts Postman v2.1 to NC Native.', async () => {
             const src = await loadKnownGoodPostman2_1Format();
-            await convertFormats(src, formats['nc-native']);
+            const result = await convertFormats(src, formats['nc-native']);
+
+            const expected = await getContents('src/file_io/test/cases/expected.converted-from-postman-v2.1.nc.json');
+            jsonCompare(await result.stringify(), expected);
         });
 
         it('Successfully converts OpenAPI v2 to NC Native.', async () => {

--- a/packages/network-console-shared/src/index.ts
+++ b/packages/network-console-shared/src/index.ts
@@ -86,10 +86,19 @@ export { NetworkConsoleNativeFileFormat } from './file_io/native';
 
 export { serializeRequest } from './file_io/serialize';
 import CollectionFormats, { environmentFormats } from './file_io';
+
+// When the TypeScript compiler emits the properties of FileFormats.Collections, if these
+// interfaces are not imported, it emits a `typeof import("...")` type declaration for
+// those properties. These types need to be imported here so that the TypeScript compiler
+// can name them when the output .d.ts file is generated.
 import { ICollectionFormat, IEnvironmentFormat } from './file_io/interfaces';
+import { convertFormats, convertEnvironment } from './file_io/convert';
 export namespace FileFormats {
     export const Collections = CollectionFormats;
     export const Environments = environmentFormats;
+
+    export const convertCollectionFormat = convertFormats;
+    export const convertEnvironmentFormat = convertEnvironment;
 }
 
 export { Lazy, default as lazy } from './util/lazy';

--- a/packages/network-console-shared/src/index.ts
+++ b/packages/network-console-shared/src/index.ts
@@ -78,12 +78,16 @@ export {
     ICollectionEntryAdapter,
     ICollectionFormat,
     ICollectionItemAdapter,
+    IEnvironmentAdapter,
+    IEnvironmentContainerAdapter,
+    IEnvironmentFormat,
 } from './file_io/interfaces';
 export { NetworkConsoleNativeFileFormat } from './file_io/native';
 
 import { ICollectionFormat } from './file_io/interfaces';
 export { serializeRequest } from './file_io/serialize';
 import CollectionFormats, { environmentFormats } from './file_io';
+import { ICollectionFormat, IEnvironmentFormat } from './file_io/interfaces';
 export namespace FileFormats {
     export const Collections = CollectionFormats;
     export const Environments = environmentFormats;

--- a/packages/network-console-shared/src/index.ts
+++ b/packages/network-console-shared/src/index.ts
@@ -81,11 +81,12 @@ export {
 } from './file_io/interfaces';
 export { NetworkConsoleNativeFileFormat } from './file_io/native';
 
-import CollectionFormats from './file_io';
 import { ICollectionFormat } from './file_io/interfaces';
 export { serializeRequest } from './file_io/serialize';
+import CollectionFormats, { environmentFormats } from './file_io';
 export namespace FileFormats {
     export const Collections = CollectionFormats;
+    export const Environments = environmentFormats;
 }
 
 export { Lazy, default as lazy } from './util/lazy';

--- a/packages/network-console-shared/src/index.ts
+++ b/packages/network-console-shared/src/index.ts
@@ -84,7 +84,6 @@ export {
 } from './file_io/interfaces';
 export { NetworkConsoleNativeFileFormat } from './file_io/native';
 
-import { ICollectionFormat } from './file_io/interfaces';
 export { serializeRequest } from './file_io/serialize';
 import CollectionFormats, { environmentFormats } from './file_io';
 import { ICollectionFormat, IEnvironmentFormat } from './file_io/interfaces';

--- a/scripts/tasks/stage-shared-component-to-dist.js
+++ b/scripts/tasks/stage-shared-component-to-dist.js
@@ -10,6 +10,9 @@ const COPYRIGHT_HEADER = `/**
  */
 `;
 
+const NCS_REFERENCE_HEADER = `/// <reference path="./network-console-shared.d.ts" />
+`;
+
 /**
  * Copies the output files from network-console-shared's local build output folder
  * to the output folder for the top-level project.
@@ -34,7 +37,7 @@ module.exports = async function stageSharedBuildOutputToDistFolder() {
     await copyAndUpdateFile(
         path.join(ncsBuildOutputPath, 'index.d.ts'),
         path.join(targetOutputPath, 'index.d.ts'),
-        COPYRIGHT_HEADER,
+        COPYRIGHT_HEADER + NCS_REFERENCE_HEADER,
         /* suffix: */ 'export as namespace NCShared;\n',
         /* replacements: */ [{
             from: / from \'\.\//g,


### PR DESCRIPTION
The File-IO feature that enables Network Console to read and write collections has been stabilizing while working on a similar fork for Environments. Before we land everything, I want to get these merged up so it's a single collective group that's been tested in totality.