### PR TITLE
Changing raw text radio title from 'raw' to 'raw text'

### DIFF
--- a/packages/devtools-network-console/src/ui/RequestBody/index.tsx
+++ b/packages/devtools-network-console/src/ui/RequestBody/index.tsx
@@ -155,7 +155,7 @@ export function RequestBody(props: IRequestBodyEditorProps) {
                         name="bodyType"
                         value="Raw text"
                         checked={props.bodySelection === 'raw'}
-                        title="raw"
+                        title="raw text"
                         label={(cn) => <label {...Styles.BODY_SELECT_LABEL} htmlFor="bodyRaw" className={cn}><LocText textKey="RequestEditor.BodyType.rawText" /></label>}
                         onChange={() => dispatch(setBodyTypeAction(props.requestId, 'raw'))}
                         />

--- a/packages/devtools-network-console/src/ui/RequestBody/index.tsx
+++ b/packages/devtools-network-console/src/ui/RequestBody/index.tsx
@@ -155,7 +155,7 @@ export function RequestBody(props: IRequestBodyEditorProps) {
                         name="bodyType"
                         value="Raw text"
                         checked={props.bodySelection === 'raw'}
-                        title="Raw text"
+                        title={getText('RequestEditor.BodyType.rawText', { locale })}
                         label={(cn) => <label {...Styles.BODY_SELECT_LABEL} htmlFor="bodyRaw" className={cn}><LocText textKey="RequestEditor.BodyType.rawText" /></label>}
                         onChange={() => dispatch(setBodyTypeAction(props.requestId, 'raw'))}
                         />

--- a/packages/devtools-network-console/src/ui/RequestBody/index.tsx
+++ b/packages/devtools-network-console/src/ui/RequestBody/index.tsx
@@ -155,7 +155,7 @@ export function RequestBody(props: IRequestBodyEditorProps) {
                         name="bodyType"
                         value="Raw text"
                         checked={props.bodySelection === 'raw'}
-                        title="raw text"
+                        title="Raw text"
                         label={(cn) => <label {...Styles.BODY_SELECT_LABEL} htmlFor="bodyRaw" className={cn}><LocText textKey="RequestEditor.BodyType.rawText" /></label>}
                         onChange={() => dispatch(setBodyTypeAction(props.requestId, 'raw'))}
                         />


### PR DESCRIPTION
Modifying the title of the raw text radio button to match the value.  This produces a more consistent and expected screen reader experience (Narrator).

Before:
- SR would read "raw, raw text radio button"

After:
- SR reads "raw text radio button"