### PR TITLE
[Narrator]: Adding gridcell role to header cells

### DIFF
--- a/packages/devtools-network-console/src/ui/ResponseViewer/index.tsx
+++ b/packages/devtools-network-console/src/ui/ResponseViewer/index.tsx
@@ -48,7 +48,7 @@ const headersColumns: DataGridColumn[] = [
         columnWidth: '20%',
         cell: (config: DataGridCellRenderConfig) => {
             return (
-                <div className={config.classNames}>
+                <div role="gridcell" className={config.classNames}>
                     <CanonicalHeaderName header={(config.rowData as any)[config.columnDataKey]} />
                 </div>
             );


### PR DESCRIPTION
Issue:
- Headers grid has broken Narrator grid traversal functionality
    - Should be able to navigate between cells using CTRL + ALT + Arrow keys

Changes:
- Adding missing `role=gridcell` attribute to the divs containing the `CanonicalHeaderName`

Video demonstrating bug:
https://user-images.githubusercontent.com/14304598/104069847-709c7200-51ba-11eb-87a2-61dfd91e2ab5.mp4

