### PR TITLE
Fix for #52: Test for headers isActive

### DIFF
--- a/packages/devtools-network-console/public/index.html
+++ b/packages/devtools-network-console/public/index.html
@@ -13,7 +13,7 @@
         default-src 'self' blob:;
         style-src 'self' 'unsafe-inline' https://devtools.azureedge.net;
         font-src 'self' https://static2.sharepointonline.com https://spoprod-a.akamaihd.net https://devtools.azureedge.net;
-        script-src 'self' 'unsafe-inline' https://devtools.azureedge.net;
+        script-src 'self' 'unsafe-inline' 'unsafe-eval' https://devtools.azureedge.net;
         img-src 'self' data:;
         worker-src 'self' https://devtools.azureedge.net data:;
       "

--- a/packages/devtools-network-console/src/utility/environment-merge.ts
+++ b/packages/devtools-network-console/src/utility/environment-merge.ts
@@ -9,20 +9,22 @@ export function mergeEnvironments(params: INetConsoleParameter[], environment: I
     const active = environment.filter(e => e.isActive);
     const map = toESMap(active, e => e.key);
 
-    return params.map(p => {
-        if (isFormDataParameter(p) && p.type === 'file') {
-            return p;
-        }
+    return params
+            .filter(p => p.isActive)
+            .map(p => {
+                if (isFormDataParameter(p) && p.type === 'file') {
+                    return p;
+                }
 
-        const { value } = mergeStringWithDurableMap(p.value, map);
-        const { description, isActive, key } = p;
-        return {
-            description,
-            isActive,
-            key,
-            value,
-        };
-    });
+                const { value } = mergeStringWithDurableMap(p.value, map);
+                const { description, isActive, key } = p;
+                return {
+                    description,
+                    isActive,
+                    key,
+                    value,
+                };
+            });
 }
 
 export function mergeString(s: string, environment: INetConsoleParameter[]): { value: string; hasSubstitutions: boolean; } {

--- a/packages/devtools-network-console/src/utility/http-compose.ts
+++ b/packages/devtools-network-console/src/utility/http-compose.ts
@@ -182,5 +182,7 @@ export function substituteRouteParameters(baseUrl: string, routes: IMap<string, 
 export function concatenateQuery(query: INetConsoleParameter[], environmentVariables: INetConsoleParameter[]): string {
     const merged = mergeEnvironments(query, environmentVariables);
     const enc = encodeURIComponent;
-    return merged.map(q => `${enc(q.key)}=${enc(q.value)}`).join('&');
+    return merged
+            .filter(q => q.isActive)
+            .map(q => `${enc(q.key)}=${enc(q.value)}`).join('&');
 }


### PR DESCRIPTION
Multiple components do not correctly check for `INetConsoleParameter#isActive`. This fix addresses these sections.